### PR TITLE
Added capability to reshow onboarding

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -119,7 +119,7 @@ class FeatureLoader extends React.Component<Props, State> {
     lon: null,
     zoom: null,
     isFilterToolbarVisible: false,
-    isOnboardingVisible: isOnboardingVisible(),
+    isOnboardingVisible: false,
     isNotFoundVisible: false,
     category: null,
     isLocalizationLoaded: false,
@@ -162,6 +162,13 @@ class FeatureLoader extends React.Component<Props, State> {
     this.setState({ isNotFoundVisible: true, lastError: error });
   }
 
+  constructor(props: Props) {
+    super(props);
+
+    if (isOnboardingVisible()) {
+      this.props.history.replace(props.history.location.pathname, { isOnboardingVisible: true });
+    }
+  }
 
   async componentWillMount() {
     this.onHashUpdate();
@@ -186,6 +193,11 @@ class FeatureLoader extends React.Component<Props, State> {
 
     if (this.featureId(props) !== this.featureId(this.props)) {
       this.setState({ isFilterToolbarVisible: false });
+    }
+
+    const state = this.props.history.location.state;
+    if (state) {
+      this.setState({ isOnboardingVisible: !!state.isOnboardingVisible });
     }
 
     const routeInformation = this.routeInformation(props);
@@ -383,6 +395,7 @@ class FeatureLoader extends React.Component<Props, State> {
         onToggle={isMainMenuOpen => this.setState({ isMainMenuOpen })}
         isEditMode={isEditMode}
         isLocalizationLoaded={isLocalizationLoaded}
+        history={this.props.history}
         { ...{lat, lon, zoom}}
       />
 
@@ -467,7 +480,7 @@ class FeatureLoader extends React.Component<Props, State> {
         isVisible={this.state.isOnboardingVisible}
         onClose={() => {
           saveOnboardingFlag();
-          this.setState({ isOnboardingVisible: false });
+          this.props.history.push(this.props.history.location.pathname, { isOnboardingVisible: false });
           this.searchToolbar.focus();
         }}
       />

--- a/src/components/MainMenu/MainMenu.js
+++ b/src/components/MainMenu/MainMenu.js
@@ -9,6 +9,7 @@ import { t } from 'c-3po';
 import GlobalActivityIndicator from './GlobalActivityIndicator';
 import { Dots } from 'react-activity';
 import strings from './strings';
+import type { RouterHistory } from 'react-router-dom';
 
 
 type State = {
@@ -24,8 +25,8 @@ type Props = {
   lat: string,
   lon: string,
   zoom: string,
+  history: RouterHistory,
 };
-
 
 function MenuIcon(props) {
   return (<svg className="menu-icon" width="25px" height="18px" viewBox="0 0 25 18" version="1.1" alt="Toggle menu" {...props}>
@@ -125,6 +126,10 @@ class MainMenu extends React.Component<Props, State> {
     this.firstMenuElement.focus();
   }
 
+  returnHome =  () => {
+    this.props.history.push({ pathname: '/beta' }, { isOnboardingVisible: true });
+  }
+
   render() {
     const {
       travelGuide, getInvolved, news, press, contact, imprint, faq, addMissingPlace, findWheelchairAccessiblePlaces,
@@ -141,16 +146,23 @@ class MainMenu extends React.Component<Props, State> {
 
     if (!isLocalizationLoaded) {
       return <nav className={classList.join(' ')}>
-        <Logo className="logo" width={123} height={30} />
+        <button className="btn-unstyled">
+          <Logo className="logo" width={123} height={30} />
+        </button>
         <Dots />
       </nav>
     }
 
     return (<nav className={classList.join(' ')}>
       <div className="home-link">
-        <a href="/beta" ref={homeLink => this.homeLink = homeLink} tabIndex={isEditMode ? -1 : 0} aria-label={t`Home`}>
+        <button 
+          className="btn-unstyled" 
+          onClick={this.returnHome} 
+          ref={homeLink => this.homeLink = homeLink} 
+          tabIndex={isEditMode ? -1 : 0} 
+          aria-label={t`Home`}>
           <Logo className="logo" width={123} height={30} />
-        </a>
+        </button>
       </div>
 
       <div className="claim">
@@ -162,7 +174,7 @@ class MainMenu extends React.Component<Props, State> {
       <div className="flexible-separator" />
 
       <button
-        className="menu"
+        className="btn-unstyled menu"
         onClick={() => this.toggleMenu()}
         tabIndex={this.state.isMenuButtonVisible ? 0 : -1}
         aria-hidden={!this.state.isMenuButtonVisible}
@@ -296,6 +308,12 @@ const StyledMainMenu = styled(MainMenu)`
     }
   }
 
+  button.btn-unstyled {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+  }
+
   button.menu {
     position: fixed;
     top: 0;
@@ -309,9 +327,6 @@ const StyledMainMenu = styled(MainMenu)`
     display: flex;
     align-items: center;
     justify-content: center;
-    border: none;
-    background: transparent;
-    cursor: pointer;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.3s ease-out;


### PR DESCRIPTION
- Changed wheelmap logo to redirect via history, not
  by AnchorElement
- The home link contains state information in addition
  to the location, to allow showing the onboarding again
- App.js handles the incoming state information