### PR TITLE
Ensure that highlights are always visible

### DIFF
--- a/src/Map.css
+++ b/src/Map.css
@@ -130,36 +130,26 @@ body.is-touch-device .leaflet-filter-button {
 
 @keyframes popUp {
   0% {
-    transform: scale3d(0.7, 0.7, 0.7) translate3d(0, -5px, 0);
-    /* background-color: black; */
+    transform: scale3d(0.3, 0.3, 0.3) translate3d(0, -5px, 0);
+  }
+  50% {
+    transform: scale3d(.75, .75, .75) translate3d(0, -20px, 0);
   }
   100% {
-    transform: scale3d(1, 1, 1) translate3d(0, -20px, 0);
-    /* background-color: white; */
+    transform: scale3d(1, 1, 1) translate3d(0, 0px, 0);
   }
-}
-
-.ac-big-icon-marker {
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 30px;
-  z-index: 200;
-  transform: scale3d(1, 1, 1) translate3d(0, -20px, 0);
-  left: calc(50% - 30px);
-  top: calc(50% - 30px);
 }
 
 .marker-icon {
   border-radius: 100%;
 }
 
-.ac-big-icon-marker.animated {
-  animation: popUp 0.15s ease-out;
+.highlighted-marker.animated figure {
+  animation: popUp 0.2s ease;
+  transform: scale3d(1, 1, 1) translate3d(0, 0px, 0);
 }
 
-.ac-big-icon-marker svg {
+.highlighted-marker svg {
   width: 30px;
   height: 30px;
 }

--- a/src/components/Map/MarkerIcon.js
+++ b/src/components/Map/MarkerIcon.js
@@ -21,16 +21,19 @@ export default class MarkerIcon extends L.Icon {
   constructor(options: Options) {
     // increased tap region for icons, rendered size might differ
     const size = 60;
+    const iconAnchorOffset = options.iconAnchorOffset || L.point(0, 0);
     const defaults = {
       number: '',
       shadowUrl: null,
       iconSize: new L.Point(size, size),
-      iconAnchor: new L.Point(size * .5, size * .5 + 1.5),
+      iconAnchor: new L.Point(size * .5 + iconAnchorOffset.x, size * .5 + 1.5 + iconAnchorOffset.y),
       popupAnchor: new L.Point(size * .5, size * .5),
       tooltipAnchor: new L.Point(size * .5, size * .5 + 25),
       onClick: ((featureId: string, properties: ?NodeProperties) => {}),
       hrefForFeature: ((featureId: string) => null),
       className: 'marker-icon',
+      size: 'small',
+      withArrow: false,
     };
 
     super(Object.assign(defaults, options));
@@ -52,9 +55,10 @@ export default class MarkerIcon extends L.Icon {
           accessibility={accessibility}
           properties={properties}
           category={iconName}
-          size='small'
+          size={this.options.size}
+          withArrow={this.options.withArrow}
           shadowed
-          ariaHidden={true}
+          ariaHidden={this.options.ariaHidden}
         />,
         link,
       );

--- a/src/components/Map/highlightMarkers.js
+++ b/src/components/Map/highlightMarkers.js
@@ -1,22 +1,21 @@
 // @flow
 
+import L from 'leaflet';
 import HighlightableMarker from './HighlightableMarker';
-// import { getFeatureId } from '../../lib/Feature';
 import difference from 'lodash/difference';
 import union from 'lodash/union';
 
 let currentHighlightedMarkers: HighlightableMarker[] = [];
 
-export default function highlightMarkers(markers: HighlightableMarker[], removeOldMarkers: boolean = true, isAnimated: boolean = true) {
-  
-  const highlightableMarkers = markers.filter(m => { return m && m.getElement() != null});
+export default function highlightMarkers(highlightLayer: L.Layer, markers: HighlightableMarker[], removeOldMarkers: boolean = true, isAnimated: boolean = true) {
+  const highlightableMarkers = markers;
   const removedMarkers = difference(currentHighlightedMarkers, highlightableMarkers);
 
   // always rehighlight, markers tend to lose additional classes when getting temp removed by leaflet
-  markers.forEach(marker => marker.highlight(isAnimated));
+  markers.forEach(marker => marker.highlight(highlightLayer, isAnimated));
   if (removeOldMarkers) {
-    removedMarkers.forEach(marker => marker.unhighlight());
-    currentHighlightedMarkers = highlightableMarkers;
+    removedMarkers.forEach(marker => marker.unhighlight(highlightLayer));
+    currentHighlightedMarkers = difference(highlightableMarkers, removedMarkers);
   } else {
     currentHighlightedMarkers = union(highlightableMarkers, currentHighlightedMarkers);
   }

--- a/src/lib/Categories.js
+++ b/src/lib/Categories.js
@@ -37,7 +37,7 @@ type SynonymCache = {
 
 
 export default class Categories {
-  static synonymCache: SynonymCache;
+  static synonymCache: SynonymCache = {};
   static idsToWheelmapCategories = {};
   static wheelmapCategoryNamesToCategories = {};
   static wheelmapRootCategoryNamesToCategories = {};


### PR DESCRIPTION
- Instead of modifying the actual marker, add another
  highlight marker on a separate layer
- This is visible on all zoom levels and not part of
  any clusters
- Cleaned up highlight management a bit