### PR TITLE
Reset search when tapping category

### DIFF
--- a/src/Map.css
+++ b/src/Map.css
@@ -400,55 +400,84 @@ body.is-touch-device .leaflet-filter-button {
 }
 
 .zoom-info-block {
-  margin-top: 67.5px;
+  display: inline-flex;
   position: absolute;
+  right: 60px;
+  top: 10px;
+  max-width: 100px; /* Ensure the block does not overlap the search bar */
   z-index: 2000;
   border-radius: 4px;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.2);
   color: rgba(0, 0, 0, 0.7);
-  background-color: #fff;
-  border-bottom: 1px solid #ccc;
-  display: inline-flex;
-  padding: 2px 5px;
-  right: 60px;
-  top: 0;
+  background-color: rgb(86,105,140);
   cursor: pointer;
-  max-width: 200px;
   text-align: center;
 }
 
-@media (max-width: 500px), (max-height: 500px) {
-  .zoom-info-block {
-    max-width: 150px;
-  }
+.zoom-info-block span {
+  padding: 4px 8px;
+  background: rgb(86,105,140);
+  color: white;
+  z-index: 1;
+  border-radius: 4px;
+  font-size: .9rem;
+  font-weight: 300;
+  text-shadow: 0 0px 1px rgba(0,0,0,0.5);
 }
 
 
 /* only show nose with zoom buttons */
-body.is-touch-device .zoom-info-block {
-  margin-top: 60px;
-}
 
 body:not(.is-touch-device) .zoom-info-block::before,
 body:not(.is-touch-device) .zoom-info-block::after  {
   content: '';
   position: absolute;
   border-style: solid;
-  border-color: #ccc;
+  border-color: rgba(0, 0, 0, 0.15);
   display: block;
   width: 0;
-  top: 7px;
   left: 100%;
   border-width: 7px 0 7px 7px;
-  border-top-color: transparent !important; 
+  border-top-color: transparent !important;
   border-bottom-color: transparent !important;
 }
 
+body:not(.is-touch-device) .zoom-info-block::before {
+  filter: blur(2px);
+  top: 16px;
+}
+
 body:not(.is-touch-device) .zoom-info-block::after {
-  border-color: #fff;
-  top: 5px;
+  border-color: rgb(86,105,140);
+  top: 14px;
   border-width: 5px 0 5px 5px;
 }
+
+
+@media (max-width: 1024px) {
+  .zoom-info-block {
+    top: 60px;
+  }
+}
+
+
+@media (max-width: 500px), (max-height: 500px) {
+  /* On small viewports, move button down to make space for category view */
+  .zoom-info-block {
+    max-width: 150px;
+    top: unset;
+    right: unset;
+    bottom: 30px;
+    left: 50%;
+    transform: translate(-50%, 0);
+  }
+
+  .zoom-info-block::before,
+  .zoom-info-block::after {
+    opacity: 0;
+  }
+}
+
 
 @media (max-width: 500px), (max-height: 500px) {
   .mapbox-attribution-container {

--- a/src/Map.css
+++ b/src/Map.css
@@ -31,6 +31,7 @@ body.is-touch-device .leaflet-filter-button {
   flex: 1;
   height: 100vh;
   width: 100vw;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 .leaflet-container.focus-ring::after {

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -498,7 +498,7 @@ export default class Map extends React.Component<Props, State> {
             onClick={this.zoomIn} 
             role="button"
             tabIndex={-1}
-            aria-label={zoomCaption}>{zoomCaption}</a>);
+            aria-label={zoomCaption}><span>{zoomCaption}</span></a>);
   }
 
   render() {

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -47,7 +47,7 @@ function filterAccessibility(properties: MinimalAccessibility): ?MinimalAccessib
 
 const PositionedCloseLink = styled(CloseLink)`
   top: 5px;
-  margin: -2px;
+  margin: -5px -16px -2px -2px; /* move close button to the same position as in search toolbar */
 `;
 
 type Props = {

--- a/src/components/SearchToolbar/SearchToolbar.js
+++ b/src/components/SearchToolbar/SearchToolbar.js
@@ -249,9 +249,6 @@ export default class SearchToolbar extends React.Component<Props, State> {
     this.setState({ searchResults: null, searchFieldIsFocused: true, isCategoryFocused: false }, () => {
       if (this.input instanceof HTMLInputElement) {
         this.input.value = '';
-        // if (!this.props.category) {
-        //   this.input.blur();
-        // }
       }
       if (this.props.onResetCategory) this.props.onResetCategory();
     });

--- a/src/components/SearchToolbar/SearchToolbar.js
+++ b/src/components/SearchToolbar/SearchToolbar.js
@@ -41,6 +41,7 @@ type State = {
   isLoading: boolean;
 };
 
+
 const StyledToolbar = styled(Toolbar)`
   transition: opacity 0.3s ease-out, transform 0.15s ease-out, width: 0.15s ease-out, height: 0.15s ease-out;
   display: flex;
@@ -109,6 +110,15 @@ const StyledToolbar = styled(Toolbar)`
     transform: translate3d(0, 0, 0) !important;
     z-index: 1000000000;
     border-radius: 0;
+
+    &.is-category-selected {
+      top: 60px;
+      left: 10px;
+      width: calc(100% - 70px);
+      max-height: 100%;
+      max-width: 320px;
+      margin: 0;
+    }
 
     > header, .search-results, .category-menu {
       padding: 0
@@ -297,7 +307,8 @@ export default class SearchToolbar extends React.Component<Props, State> {
 
     const className = [
       'search-toolbar',
-      searchFieldIsFocused ? 'search-field-is-focused' : null,
+      this.props.category && 'is-category-selected',
+      searchFieldIsFocused && 'search-field-is-focused',
     ].filter(Boolean).join(' ');
 
     return (


### PR DESCRIPTION
Includes small UX improvements on the zoom hint: It's on the bottom on small viewports now, and styled like the call-to-action hint in the node toolbar.