### PR TITLE
Close modals on click outside modal

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -675,6 +675,7 @@ class FeatureLoader extends React.Component<Props, State> {
     const nodeToolbar = this.renderNodeToolbar({ isNodeRoute, featureId, equipmentInfoId, isEditMode, isReportMode });
 
     return (<div className={classList.join(' ')}>
+      {!isMainMenuInBackground && mainMenu}
       <div className="behind-backdrop">
         {isMainMenuInBackground && mainMenu}
         {isLocalizationLoaded && this.renderSearchToolbar({ isInert: searchToolbarIsInert, category, searchQuery, lat, lon })}
@@ -685,7 +686,6 @@ class FeatureLoader extends React.Component<Props, State> {
       </div>
       {this.renderFullscreenBackdrop()}
       {(this.state.isFilterToolbarVisible && isLocalizationLoaded) && this.renderFilterToolbar()}
-      {!isMainMenuInBackground && mainMenu}
       {isNodeToolbarVisible && isNodeToolbarModal && nodeToolbar}
       {this.renderOnboarding()}
       {this.renderNotFound()}

--- a/src/App.js
+++ b/src/App.js
@@ -582,7 +582,6 @@ class FeatureLoader extends React.Component<Props, State> {
 
     return <FullscreenBackdrop
       onClick={() => {
-        console.log('backdrop clicked');
         this.setState({
           isFilterToolbarVisible: false,
           isMainMenuOpen: false,

--- a/src/Map.css
+++ b/src/Map.css
@@ -29,9 +29,15 @@ body.is-touch-device .leaflet-filter-button {
 
 .leaflet-container {
   flex: 1;
-  height: 100vh;
   width: 100vw;
+  height: calc(100vh - 50px);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+@media (max-width: 1024px) {
+  .leaflet-container {
+    height: 100vh;
+  }
 }
 
 .leaflet-container.focus-ring::after {

--- a/src/components/FullscreenBackdrop.js
+++ b/src/components/FullscreenBackdrop.js
@@ -1,0 +1,21 @@
+// @flow
+
+// import * as React from 'react';
+import styled from 'styled-components';
+
+const FullscreenBackdrop = styled.div.attrs({ className: 'fullscreen-backdrop' })`
+  backdrop-filter: blur(10px);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(48, 59, 64, 0.67);
+  transition: opacity 0.3s ease-out;
+  opacity: ${props => props.isActive ? '1' : '0'};
+  pointer-events: ${props => props.isActive ? 'inherit' : 'none'} !important;
+  z-index: 1000;
+  transform: none !important;
+`;
+
+export default FullscreenBackdrop;

--- a/src/components/MainMenu/MainMenu.js
+++ b/src/components/MainMenu/MainMenu.js
@@ -13,7 +13,6 @@ import type { RouterHistory } from 'react-router-dom';
 
 
 type State = {
-  isMenuVisible: boolean,
   isMenuButtonVisible: boolean,
 };
 
@@ -21,6 +20,7 @@ type Props = {
   className: string,
   onToggle: ((isMainMenuOpen: boolean) => void),
   isEditMode: boolean,
+  isOpen: boolean,
   isLocalizationLoaded: boolean,
   lat: string,
   lon: string,
@@ -43,7 +43,6 @@ const menuButtonVisibilityBreakpoint = 1024;
 class MainMenu extends React.Component<Props, State> {
   props: Props;
   state: State = {
-    isMenuVisible: false,
     isMenuButtonVisible: window.innerWidth <= menuButtonVisibilityBreakpoint,
   };
   boundOnResize: (() => void);
@@ -73,11 +72,11 @@ class MainMenu extends React.Component<Props, State> {
     window.removeEventListener('resize', this.boundOnResize);
   }
 
-  componentDidUpdate(_, prevState) {
+  componentDidUpdate(prevProps, _) {
     if (this.state.isMenuVisible) {
       this.setupFocusTrap();
 
-      if (!prevState.isMenuVisible) {
+      if (!prevProps.isOpen) {
         this.focusFirstMenuElement();
       }
     } else {
@@ -86,12 +85,7 @@ class MainMenu extends React.Component<Props, State> {
   }
 
   toggleMenu() {
-    const newState = !this.state.isMenuVisible;
-    this.setState({
-      isMenuVisible: newState,
-    });
-
-    this.props.onToggle(newState);
+    this.props.onToggle(!this.props.isOpen);
   }
 
   setupFocusTrap() {
@@ -139,7 +133,7 @@ class MainMenu extends React.Component<Props, State> {
 
     const classList = [
       this.props.className,
-      this.state.isMenuVisible ? 'is-open' : null,
+      this.props.isOpen ? 'is-open' : null,
       isLocalizationLoaded ? 'is-loaded' : null,
       'main-menu',
     ].filter(Boolean);
@@ -182,10 +176,10 @@ class MainMenu extends React.Component<Props, State> {
         aria-hidden={!this.state.isMenuButtonVisible}
         aria-label={t`Menu`}
         aria-haspopup="true"
-        aria-expanded={this.state.isMenuVisible}
+        aria-expanded={this.props.isOpen}
         aria-controls="main-menu"
       >
-        {this.state.isMenuVisible ? <CloseIcon /> : <MenuIcon />}
+        {this.props.isOpen ? <CloseIcon /> : <MenuIcon />}
       </button>
 
       <div id="main-menu" role="menu">
@@ -383,7 +377,6 @@ const StyledMainMenu = styled(MainMenu)`
     }
 
     &.is-open {
-      background-color: rgba(254, 254, 254, 0.9);
       height: auto;
       .nav-link {
         display: flex;

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -56,7 +56,8 @@ type Props = {
   equipmentInfoId: ?string,
   hidden: boolean,
   isEditMode: boolean,
-  onReportModeToggle: ?((isReportMode: boolean) => void),
+  isReportMode: boolean,
+  onOpenReportMode: ?(() => void),
   history: RouterHistory,
   onClose?: ?(() => void),
 };
@@ -65,7 +66,6 @@ type Props = {
 type State = {
   category: ?Category,
   parentCategory: ?Category,
-  isReportMode: boolean,
   equipmentInfo: ?EquipmentInfo,
   feature: ?Feature,
 };
@@ -102,7 +102,7 @@ const FullWidthSection = styled.div`
 
 class NodeToolbar extends React.Component<Props, State> {
   props: Props;
-  state = { category: null, parentCategory: null, isReportMode: false, feature: null, equipmentInfo: null };
+  state = { category: null, parentCategory: null, feature: null, equipmentInfo: null };
   toolbar: ?React.ElementRef<typeof Toolbar>;
   nodeFooter: ?React.ElementRef<typeof NodeFooter>;
   reportDialog: ?React.ElementRef<typeof ReportDialog>;
@@ -134,19 +134,12 @@ class NodeToolbar extends React.Component<Props, State> {
 
   componentWillReceiveProps(nextProps: Props) {
     this.fetchFeature(nextProps);
-    if (nextProps.featureId !== this.props.featureId) {
-      this.toggleReportMode(false);
+    if (this.props.featureId && (nextProps.featureId !== this.props.featureId)) {
       this.setState({ equipmentInfo: null });
     }
     if (!nextProps.equipmentInfoId) {
       this.fetchCategory(nextProps.feature);
     }
-  }
-
-
-  toggleReportMode(isReportMode: boolean) {
-    this.setState({ isReportMode });
-    if (this.props.onReportModeToggle) this.props.onReportModeToggle(isReportMode);
   }
 
 
@@ -220,7 +213,7 @@ class NodeToolbar extends React.Component<Props, State> {
       }
     }
 
-    if (prevState.isReportMode && !this.state.isReportMode) {
+    if (prevProps.isReportMode && !this.props.isReportMode) {
       if (this.reportModeButton) {
         this.reportModeButton.focus();
       }
@@ -278,7 +271,7 @@ class NodeToolbar extends React.Component<Props, State> {
     return (
       <StyledToolbar
         hidden={this.props.hidden}
-        isModal={this.props.isEditMode || this.state.isReportMode}
+        isModal={this.props.isEditMode || this.props.isReportMode}
         innerRef={(toolbar) => { this.toolbar = toolbar; }}
         role="dialog"
         ariaLabel={placeName}
@@ -286,7 +279,7 @@ class NodeToolbar extends React.Component<Props, State> {
         {this.props.isEditMode ? null : <PositionedCloseLink
           history={this.props.history}
           onClick={() => {
-            this.toggleReportMode(false);
+            console.log('Node toolbar close link clicked');
             if (this.props.onClose) this.props.onClose();
           }}
         />}
@@ -297,17 +290,17 @@ class NodeToolbar extends React.Component<Props, State> {
           equipmentInfoId={this.props.equipmentInfoId}
           category={this.state.category}
           parentCategory={this.state.parentCategory}
-          showOnlyBasics={this.props.isEditMode || this.state.isReportMode}
+          showOnlyBasics={this.props.isEditMode || this.props.isReportMode}
         />
 
         {(() => {
-          if (this.state.isReportMode && !isEquipment) {
+          if (this.props.isReportMode && !isEquipment) {
             return (<ReportDialog
               innerRef={reportDialog => this.reportDialog = reportDialog}
               feature={this.props.feature}
               featureId={this.props.featureId}
               onClose={() => {
-                this.toggleReportMode(false);
+                if (this.props.onClose) this.props.onClose();
               }}
             />);
           }
@@ -370,7 +363,7 @@ class NodeToolbar extends React.Component<Props, State> {
               ref={reportModeButton => this.reportModeButton = reportModeButton}
               className="link-button full-width-button"
               onClick={() => {
-                this.toggleReportMode(true);
+                if (this.props.onOpenReportMode) this.props.onOpenReportMode();
               }}
             >
               {reportButtonCaption}

--- a/src/components/Onboarding/Onboarding.js
+++ b/src/components/Onboarding/Onboarding.js
@@ -119,8 +119,8 @@ const StyledOnboarding = styled(Onboarding)`
       flex-direction: column !important;
       > footer, > header {
         text-align: center;
-        width: 75%;
-        margin: 0 12.5%;
+        max-width: 500px;
+        align-self: center;
       }
     }
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -297,7 +297,6 @@ const StyledToolbar = styled(Toolbar)`
   }
 
   box-sizing: border-box;
-  z-index: 1001;
   overflow: auto;
   transform: translate3d(0, 0);
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 html {
-  background-color: #E6E4E0;
+  background-color: #6c7374;
 }
 
 body {


### PR DESCRIPTION
This adds a fullscreen backdrop modal component with subtle 3D effect, to be used when you want to display something modally.

To be compatible to all platforms, it's not using `-webkit-backdrop-filter`, but encapsulates everything to be blurry behind the modal dialog in a `<div>` with a `filter` CSS property.

It's not perfectly generic, but works for all our states so far, unifying their look :)

The new code also moves some component state (isReportMode/isEditMode) to the outside of the node toolbars to simplify things.