### PR TITLE
Handle empty results & error response in search

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -224,6 +224,10 @@ class Loader extends React.Component<Props, State> {
       }
     }
 
+    if (searchQuery && searchQuery.length > 0) {
+      result.isSearchBarVisible = true;
+    }
+
     if (featureIdHasChanged || equipmentIdHasChanged) {
       result.isSearchToolbarExpanded = false;
       if (category || isFiltered(accessibilityFilter)) {

--- a/src/App.js
+++ b/src/App.js
@@ -226,11 +226,12 @@ class Loader extends React.Component<Props, State> {
 
     if (searchQuery && searchQuery.length > 0) {
       result.isSearchBarVisible = true;
-    }
-
-    if (featureIdHasChanged || equipmentIdHasChanged) {
+      result.isSearchToolbarExpanded = true;
+    } else if (featureIdHasChanged || equipmentIdHasChanged) {
       result.isSearchToolbarExpanded = false;
-      if (category || isFiltered(accessibilityFilter)) {
+
+      // always minify search bar on small viewport or when filtered
+      if (state.isOnSmallViewport || category || isFiltered(accessibilityFilter)) {
         result.isSearchBarVisible = false;
       }
     }

--- a/src/components/SearchToolbar/SearchResults.js
+++ b/src/components/SearchToolbar/SearchResults.js
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 
 import type { RouterHistory } from 'react-router-dom';
 import type { SearchResultCollection } from '../../lib/searchPlaces';
+import colors from '../../lib/colors';
 
 import SearchResult from './SearchResult';
 
@@ -83,7 +84,7 @@ const StyledSearchResults = styled(SearchResults)`
     overflow: hidden;
     padding: 20px;
     font-weight: 400;
-    background-color: #ffbab2;
+    background-color: ${colors.negativeBackgroundColorTransparent};
   }
 
   .osm-category-place-borough,

--- a/src/components/SearchToolbar/SearchResults.js
+++ b/src/components/SearchToolbar/SearchResults.js
@@ -24,7 +24,19 @@ type Props = {
 function SearchResults(props: Props) {
   const id = result => result && result.properties && result.properties.osm_id;
   const features = uniq(props.searchResults.features, id);
+
+  const failedLoading = !!props.searchResults.error;
+  const hasNoResults = !failedLoading && features.length === 0;
+
+  // translator: Text in search results when nothing was found
+  const noResultsFoundCaption = t`No results found.`;
+
+  // translator: Text in search results when an error occurred
+  const searchErrorCaption = t`Failed loading results. Please try again later`;
+
   return (<ul className={`search-results ${props.className}`} aria-label={t`Search results`}>
+    {failedLoading && <li className="error-result">{searchErrorCaption}</li>} 
+    {hasNoResults && <li className="no-result">{noResultsFoundCaption}</li>} 
     {features.map(result => (<SearchResult
       result={result}
       key={id(result)}
@@ -56,6 +68,22 @@ const StyledSearchResults = styled(SearchResults)`
     address {
       font-size: 16px !important;
     }
+  }
+
+  li.no-result {
+    text-align: center;
+    font-size: 16px;
+    overflow: hidden;
+    padding: 20px;
+  }
+
+  li.error-result {
+    text-align: center;
+    font-size: 16px;
+    overflow: hidden;
+    padding: 20px;
+    font-weight: 400;
+    background-color: #ffbab2;
   }
 
   .osm-category-place-borough,

--- a/src/components/SearchToolbar/SearchToolbar.js
+++ b/src/components/SearchToolbar/SearchToolbar.js
@@ -232,6 +232,10 @@ export default class SearchToolbar extends React.Component<Props, State> {
     if (searchFieldShouldBecomeFocused) {
       this.focus();
     }
+
+    if (prevProps.searchQuery !== this.props.searchQuery) {
+      this.sendSearchRequest(this.props.searchQuery);
+    }
   }
 
   ensureFullVisibility() {
@@ -240,7 +244,7 @@ export default class SearchToolbar extends React.Component<Props, State> {
     }
   }
 
-  sendSearchRequest(query: string): void {
+  sendSearchRequest(query: ?string): void {
     if (!query || query.length < 3) {
       this.setState({ searchResults: null, isLoading: false });
       return;

--- a/src/lib/searchPlaces.js
+++ b/src/lib/searchPlaces.js
@@ -29,9 +29,8 @@ export type SearchResultFeature = {
 
 export type SearchResultCollection = {
   features: SearchResultFeature[],
+  error?: Error,
 };
-
-
 
 let queryIndex: number = 0;
 
@@ -67,5 +66,8 @@ export default function searchPlaces(query: string, { lat, lon }: { lat?: ?numbe
       return null;
     }
     return response.json();
+  }).catch(error => {
+    // handle error & forward to results
+    return {features: [], error };
   });
 }


### PR DESCRIPTION
- Show search results when starting on a /search?q=... route
- Ensure that any error in the search promise is caught
- Display 'No results' for empty list
- Display 'Error' for failed requests
- Rudimentary styling