### PR TITLE
Fix onboarding link on Cordova/mobile

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import includes from 'lodash/includes';
 import queryString from 'query-string';
 import initReactFastclick from 'react-fastclick';
 import type { RouterHistory, Location } from 'react-router-dom';
-import { BrowserRouter, HashRouter, Route } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter, Route } from 'react-router-dom';
 
 import { saveOnboardingFlag, isOnboardingVisible } from './components/Onboarding/Onboarding';
 
@@ -517,8 +517,7 @@ class Loader extends React.Component<Props, State> {
 
 
 function App() {
-  const Router = window.cordova ? HashRouter : BrowserRouter;
-  // const Router = HashRouter;
+  const Router = window.cordova ? MemoryRouter : BrowserRouter;
 
   return (<Router>
     <Route path="/" component={Loader} />


### PR DESCRIPTION
We currently use `react-router`’s `HashRouter`, which internally does not support supplying a state object to `history.push`. In Cordova apps, you currently can’t tap the logo to open the onboarding dialog. This PR fixes the problem by using `MemoryRouter` instead.