### PR TITLE
Expand node toolbar when opening a PoI on mobile

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -312,22 +312,17 @@ class Loader extends React.Component<Props, State> {
     const searchToolbarDidAppear = isSearchToolbarDisplayed && !wasSearchToolbarDisplayed;
 
     if ((nodeToolbarDidDisappear || searchToolbarDidDisappear)) {
-      console.log('Focusing', this.lastFocusedElement);
       window.document.activeElement.blur();
       if (this.lastFocusedElement) this.lastFocusedElement.focus();
     }
 
     if ((nodeToolbarDidAppear || featureIdHasChanged) && this.mainView.nodeToolbar) {
       this.lastFocusedElement = document.activeElement;
-      console.log('Saving last focused element:', this.lastFocusedElement);
-      console.log('Focusing', this.mainView.nodeToolbar);
       this.mainView.nodeToolbar.focus();
     }
 
     if (searchToolbarDidAppear && this.mainView.searchToolbar) {
       this.lastFocusedElement = document.activeElement;
-      console.log('Saving last focused element:', this.lastFocusedElement);
-      console.log('Focusing', this.mainView.searchToolbar);
       this.mainView.searchToolbar.focus();
     }
   }

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -291,7 +291,6 @@ class NodeToolbar extends React.Component<Props, State> {
         {this.props.isEditMode ? null : <PositionedCloseLink
           history={this.props.history}
           onClick={() => {
-            console.log('Node toolbar close link clicked');
             if (this.props.onClose) this.props.onClose();
           }}
         />}

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -286,7 +286,7 @@ class NodeToolbar extends React.Component<Props, State> {
         innerRef={(toolbar) => { this.toolbar = toolbar; }}
         role="dialog"
         ariaLabel={placeName}
-        startTopOffset={hasBigViewport() ? 0 : (window.innerHeight / 2)}
+        startTopOffset={hasBigViewport() ? 0 : (0.4 * window.innerHeight)}
       >
         {this.props.isEditMode ? null : <PositionedCloseLink
           history={this.props.history}

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -35,6 +35,7 @@ import type { EquipmentInfo } from '../../lib/EquipmentInfo';
 import { placeNameFor, isWheelmapFeatureId, removeNullAndUndefinedFields } from '../../lib/Feature';
 import { generateMapsUrl } from '../../lib/generateMapsUrls';
 import { equipmentInfoCache } from '../../lib/cache/EquipmentInfoCache';
+import { hasBigViewport } from '../../lib/ViewportSize';
 
 function filterAccessibility(properties: MinimalAccessibility): ?MinimalAccessibility {
   // These attributes have a better representation in the UI than the basic tree structure would provide.
@@ -285,6 +286,7 @@ class NodeToolbar extends React.Component<Props, State> {
         innerRef={(toolbar) => { this.toolbar = toolbar; }}
         role="dialog"
         ariaLabel={placeName}
+        startTopOffset={hasBigViewport() ? 0 : (window.innerHeight / 2)}
       >
         {this.props.isEditMode ? null : <PositionedCloseLink
           history={this.props.history}

--- a/src/components/NodeToolbar/ShareButtons/ShareButtons.js
+++ b/src/components/NodeToolbar/ShareButtons/ShareButtons.js
@@ -78,6 +78,8 @@ class ExpandableShareButtons extends React.Component<Props, State> {
   };
 
   toggle(isExpanded) {
+    const hasChanged = isExpanded !== this.state.isExpanded;
+    if (!hasChanged) return;
     this.setState({ isExpanded });
     if (this.props.onToggle) this.props.onToggle();
   }

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -84,7 +84,6 @@ class Toolbar extends React.Component<Props, State> {
 
 
   componentDidMount() {
-    console.log('Toolbar did mount.');
     this.onResize(this.props.startTopOffset);
     if (this.props.isModal) this.ensureFullVisibility();
     setTimeout(() => this.onResize(this.props.startTopOffset), 100);
@@ -98,7 +97,6 @@ class Toolbar extends React.Component<Props, State> {
 
   componentWillReceiveProps(newProps: Props) {
     if (newProps.isModal !== this.props.isModal) {
-      console.log('Toolbar became modal.');
       this.ensureFullVisibility();
     }
   }
@@ -106,7 +104,6 @@ class Toolbar extends React.Component<Props, State> {
 
   /** Moves the toolbar to show as much of its content as possible. */
   ensureFullVisibility() {
-    console.log('Ensuring full toolbar visibility');
     setTimeout(() => {
       this.setState({ topOffset: 0 });
       this.onResize();
@@ -189,7 +186,6 @@ class Toolbar extends React.Component<Props, State> {
         result = stop;
       }
     });
-    console.log('Nearest offset for preferred offset', topOffset, 'is', result, '- stops:', stops);
     return result;
   }
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -196,7 +196,7 @@ class Toolbar extends React.Component<Props, State> {
 
   /** @returns the maximal top position for the toolbar to stay interactable. */
 
-  getMaximalTopPosition(): number {
+  getTopmostPosition(): number {
     let toolbarHeight = 0;
     if (this.scrollElement) {
       const style = window.getComputedStyle(this.scrollElement);
@@ -211,7 +211,7 @@ class Toolbar extends React.Component<Props, State> {
   /** @returns An array of top position offsets that the toolbar is allowed to stop on. */
 
   getStops(): number[] {
-    const maximalTopPosition = this.getMaximalTopPosition();
+    const maximalTopPosition = this.getTopmostPosition();
     const stops = uniq([
       maximalTopPosition,
       Math.max(maximalTopPosition, Math.floor(this.state.viewportSize.height / 2)),
@@ -231,7 +231,7 @@ class Toolbar extends React.Component<Props, State> {
     const lastTopOffset = this.state.lastTopOffset;
 
     let topOffset = this.state.topOffset || this.state.lastTopOffset;
-    topOffset = Math.max(this.getMaximalTopPosition(), topOffset);
+    topOffset = Math.max(this.getTopmostPosition(), topOffset);
     const isLandscape = this.state.viewportSize.width > this.state.viewportSize.height;
     const isBigViewport = this.state.viewportSize.width > 512;
     if (isLandscape || isBigViewport) {
@@ -242,7 +242,7 @@ class Toolbar extends React.Component<Props, State> {
     const isSwiping = this.state.isSwiping;
     const { enableTransitions } = this.props;
     return {
-      touchAction: lastTopOffset === this.getMaximalTopPosition() ? 'inherit' : 'none',
+      touchAction: lastTopOffset === this.getTopmostPosition() ? 'inherit' : 'none',
       transition: enableTransitions ? (isSwiping ? defaultTransitions : `${defaultTransitions}, transform 0.3s ease-out`) : '',
       transform: `translate3d(0, ${topOffset}px, 0)`,
     };

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -87,7 +87,7 @@ class Toolbar extends React.Component<Props, State> {
     console.log('Toolbar did mount.');
     this.onResize(this.props.startTopOffset);
     if (this.props.isModal) this.ensureFullVisibility();
-    setTimeout(() => this.onResize(this.props.startTopOffset), 500);
+    setTimeout(() => this.onResize(this.props.startTopOffset), 100);
   }
 
 


### PR DESCRIPTION
This expands the toolbar to cover around half of the screen when opening the first PoI.