### PR TITLE
Fix missing wheelmap PoIs when opening category URL directly

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -221,20 +221,6 @@ export default class Map extends React.Component<Props, State> {
     this.featureLayer = new L.LayerGroup();
     this.featureLayer.addLayer(markerClusterGroup);
 
-    const wheelmapTileUrl = this.wheelmapTileUrl();
-
-    if (wheelmapTileUrl) {
-      this.wheelmapTileLayer = new GeoJSONTileLayer(wheelmapTileUrl, {
-        featureCache: wheelmapLightweightFeatureCache,
-        layerGroup: markerClusterGroup,
-        featureCollectionFromResponse: wheelmapFeatureCollectionFromResponse,
-        pointToLayer: this.props.pointToLayer,
-        filter: this.isFeatureVisible.bind(this),
-        maxZoom: this.props.maxZoom,
-        cordova: true,
-      });
-    }
-
     loadExistingLocalizationByPreference().then(() => {
       const locale = currentLocales[0];
       const accessibilityCloudTileUrl = this.props.accessibilityCloudTileUrl(locale);
@@ -254,6 +240,7 @@ export default class Map extends React.Component<Props, State> {
 
 
     Categories.fetchOnce(this.props).then(() => {
+      this.setupWheelmapTileLayer(markerClusterGroup);
       this.updateFeatureLayerVisibility(this.props);
       map.on('moveend', () => { this.updateFeatureLayerVisibility(); });
       map.on('zoomend', () => { this.updateFeatureLayerVisibility(); });
@@ -280,6 +267,23 @@ export default class Map extends React.Component<Props, State> {
     delete this.wheelmapTileLayer;
     delete this.accessibilityCloudTileLayer;
   }
+
+
+  setupWheelmapTileLayer(markerClusterGroup: L.MarkerClusterGroup) {
+    const wheelmapTileUrl = this.wheelmapTileUrl();
+    if (wheelmapTileUrl) {
+      this.wheelmapTileLayer = new GeoJSONTileLayer(wheelmapTileUrl, {
+        featureCache: wheelmapLightweightFeatureCache,
+        layerGroup: markerClusterGroup,
+        featureCollectionFromResponse: wheelmapFeatureCollectionFromResponse,
+        pointToLayer: this.props.pointToLayer,
+        filter: this.isFeatureVisible.bind(this),
+        maxZoom: this.props.maxZoom,
+        cordova: true,
+      });
+    }
+  }
+
 
   removeLayersNotVisibleInZoomLevel() {
     const map: L.Map = this.map;


### PR DESCRIPTION
This is fixed by waiting for categories to be loaded before showing the wheelmap feature layer.