### PR TITLE
Image scaling though ac (wheelmap-frontend-part)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
           data: gap: ws: https://www.google-analytics.com https://ssl.gstatic.com https://photon.komoot.de %REACT_APP_WHEELMAP_API_BASE_URL% %REACT_APP_ACCESSIBILITY_CLOUD_BASE_URL% %REACT_APP_ACCESSIBILITY_CLOUD_UNCACHED_BASE_URL% %REACT_APP_ALLOW_ADDITIONAL_DATA_URLS%; 
           style-src 'self' 'unsafe-inline'; 
           media-src 'self'
-          gap:; img-src 'self' https://accessibility-cloud-uploads.s3.amazonaws.com https://www.google-analytics.com https://api.mapbox.com %REACT_APP_ALLOW_ADDITIONAL_IMAGE_URLS%
+          gap:; img-src 'self' https://accessibility-cloud-uploads.s3.amazonaws.com https://www.google-analytics.com https://api.mapbox.com %REACT_APP_ACCESSIBILITY_CLOUD_BASE_URL% %REACT_APP_ALLOW_ADDITIONAL_IMAGE_URLS%
           data: https://asset0.wheelmap.org https://asset1.wheelmap.org https://asset2.wheelmap.org https://asset3.wheelmap.org https://asset4.wheelmap.org  https">
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, viewport-fit=cover" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">

--- a/src/components/NodeToolbar/Photos/PhotoModel.js
+++ b/src/components/NodeToolbar/Photos/PhotoModel.js
@@ -4,6 +4,8 @@ export type PhotoModel = {
   src: string,
   srcSet: string[],
   sizes: string[],
+  thumbnailSrcSet: string[],
+  thumbnailSizes: string[],
   width: number,
   height: number,
   imageId: string | number,

--- a/src/components/NodeToolbar/Photos/PhotoSection.js
+++ b/src/components/NodeToolbar/Photos/PhotoSection.js
@@ -67,12 +67,18 @@ class PhotoSection extends React.Component<Props, State> {
 
     this.setState({ lightBoxPhotos: [].concat(mergedPhotos) });
 
+    let galleryPhotos = [];
     if (mergedPhotos.length > 0) {
+      // use the thumbnail sizes for this
+      galleryPhotos = mergedPhotos.map(p => {
+        return Object.assign({}, p, { srcSet: p.thumbnailSrcSet || p.srcSet, sizes: p.thumbnailSizes || p.sizes });
+      });
+
       // add upload more placeholder
-      mergedPhotos.push({
+      galleryPhotos.push({
         src: addPhotoEntry,
         srcSet: [addPhotoEntry],
-        sizes: [''],
+        sizes: ['100 vw'],
         width: 1,
         height: 1,
         imageId: 'invalid-id',
@@ -80,7 +86,7 @@ class PhotoSection extends React.Component<Props, State> {
       });
     }
 
-    this.setState({ photos: mergedPhotos }, () => {
+    this.setState({ photos: galleryPhotos }, () => {
       const g : any = (this.gallery);
       g.handleResize();
     });

--- a/src/components/NodeToolbar/Photos/convertAcPhotosToLightboxPhotos.js
+++ b/src/components/NodeToolbar/Photos/convertAcPhotosToLightboxPhotos.js
@@ -1,13 +1,42 @@
 // @flow
 
+import config from '../../../lib/config';
+
 import type { PhotoModel } from './PhotoModel';
-import type { AccessibilityCloudImages } from '../../../lib/Feature';
+import type { AccessibilityCloudImage, AccessibilityCloudImages } from '../../../lib/Feature';
+
+const makeSrcUrl = (acPhoto: AccessibilityCloudImage, size: number) => {
+  return `${config.accessibilityCloudBaseUrl}/images/scale/${acPhoto.imagePath}?fitw=${size}&fith=${size}`;
+}
+
+const makeCachedImageSrcSetEntry = (acPhoto: AccessibilityCloudImage, size: number) => {
+  return `${makeSrcUrl(acPhoto, size)} ${size}w`;
+}
+
+const thumbnailSizes = [96, 192, 384];
+const thumbnailMediaSelector = [
+      `(min-resolution: 192dpi) 300px`,
+      `(min-resolution: 120dpi) 200px`,
+      `100px`];
+
+const fullScreenSizes = [480, 960, 1920];
+const fullScreenMediaSelector = [
+      `(min-width: 480) 480px`,
+      `(min-width: 960) 960px`,
+      `(min-width: 1920) 1920px`,
+      `960px`];
+
+const makeSrcSet = (sizes: number[],  acPhoto: AccessibilityCloudImage) => {
+  return sizes.map(s => makeCachedImageSrcSetEntry(acPhoto, s));
+}
 
 export default function convertAcPhotosToLightboxPhotos(acPhotos: AccessibilityCloudImages): PhotoModel[] {
   return acPhotos.images.map(acPhoto => ({
-    src: acPhoto.url,
-    srcSet: [acPhoto.url],
-    sizes: ['(min-width: 480px) 100px,33vw'],
+    src: makeSrcUrl(acPhoto, 1366),
+    srcSet: makeSrcSet(fullScreenSizes, acPhoto),
+    sizes: fullScreenMediaSelector,
+    thumbnailSrcSet: makeSrcSet(thumbnailSizes, acPhoto),
+    thumbnailSizes: thumbnailMediaSelector,
     width: acPhoto.dimensions ? acPhoto.dimensions.width : 1,
     height: acPhoto.dimensions ? acPhoto.dimensions.height : 1,
     imageId: acPhoto._id,


### PR DESCRIPTION
- Had to generate two separate source sets on for thumbs, one for the gallery
  This is still wrong for wheelmap classic photos, the large photos are used
  as thumbnails as well
- Use ac apis to get scaled photos