### PR TITLE
iOS location + data protection

### DIFF
--- a/platforms/ios/Wheelmap/Wheelmap-Info.plist
+++ b/platforms/ios/Wheelmap/Wheelmap-Info.plist
@@ -81,6 +81,8 @@
     <key>NSCameraUsageDescription</key>
     <string>You have to allow Wheelmap to use the camera to upload photos.</string>
     <key>NSLocationWhenInUseUsageDescription</key>
-    <string>Location access is used to show where you are on the map.</string>
+    <string>Location access is only used to show where you are on the map.</string>
+    <key>NSLocationAlwaysUsageDescription</key>
+    <string>Location access is only used to show where you are on the map.</string>
   </dict>
 </plist>

--- a/plugins/cordova-plugin-geolocation/src/ios/CDVLocation.m
+++ b/plugins/cordova-plugin-geolocation/src/ios/CDVLocation.m
@@ -122,8 +122,6 @@
         __highAccuracyEnabled = enableHighAccuracy;
         if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"]){
             [self.locationManager requestWhenInUseAuthorization];
-        } else if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]) {
-            [self.locationManager  requestAlwaysAuthorization];
         } else {
             NSLog(@"[Warning] No NSLocationAlwaysUsageDescription or NSLocationWhenInUseUsageDescription key is defined in the Info.plist file.");
         }


### PR DESCRIPTION
The removed `if` branch is never reached as the app only needs location when in use. Having this code in there could lead to an app store rejection.

Add `NSLocationAlwaysUsageDescription` string anyway to be safe from it missing.

Only the last commit is relevant.

Let me know when I can rebase this PR so it's easier to review :) Only the last commit below is relevant. For this we need to merge https://github.com/sozialhelden/wheelmap-react-frontend/pull/96 and https://github.com/sozialhelden/wheelmap-react-frontend/pull/97 first. 