### PR TITLE
Fix Broken Share Buttons on Mobile Apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-photo-gallery": "^6.0.25",
     "react-radio-group": "^3.0.2",
     "react-router-dom": "^4.0.0",
-    "react-share": "^1.15.1",
+    "react-share": "^2.3.1",
     "react-swipeable": "^4.0.1",
     "react-transition-group": "^1.1.1",
     "source-map-explorer": "^1.5.0",

--- a/src/components/NodeToolbar/IconButtonList/ShareButtons.js
+++ b/src/components/NodeToolbar/IconButtonList/ShareButtons.js
@@ -2,7 +2,12 @@
 
 import styled from 'styled-components';
 import * as React from 'react';
-import { ShareButtons } from 'react-share';
+import {
+  FacebookShareButton,
+  TwitterShareButton,
+  TelegramShareButton,
+  WhatsappShareButton,
+} from 'react-share';
 import { t } from 'ttag';
 import colors from '../../../lib/colors';
 import IconButton from '../../IconButton';
@@ -19,13 +24,6 @@ import EmailIcon from './icons/Email';
 import WhatsAppIcon from './icons/WhatsApp';
 
 import ShareIcon from '../../icons/actions/ShareIOS';
-
-const {
-  FacebookShareButton,
-  TwitterShareButton,
-  TelegramShareButton,
-  WhatsappShareButton
-} = ShareButtons;
 
 type Props = {
   feature: Feature;

--- a/src/components/NodeToolbar/IconButtonList/ShareButtons.js
+++ b/src/components/NodeToolbar/IconButtonList/ShareButtons.js
@@ -144,25 +144,43 @@ class ExpandableShareButtons extends React.Component<Props, State> {
 
     if (!this.state.isExpanded) return expandButton;
 
+    const openLinkViaLocationHref = link => window.location.href = link;
+
     return <div className={this.props.className}>
       <button ref={collapseButton => this.collapseButton = collapseButton} className={'link-button collapse-button'} onClick={() => this.toggle(false)} aria-expanded={this.state.isExpanded} aria-label={t`Collapse share menu`}>
         <ChevronLeft />
       </button>
 
       <footer className={this.state.isExpanded ? 'is-visible' : ''}>
-        <FacebookShareButton url={url} quote={pageDescription}>
+        <FacebookShareButton
+          url={url}
+          quote={pageDescription}
+          openWindow={false}
+          onClick={openLinkViaLocationHref}
+        >
           <StyledIconButton isHorizontal={false} hasCircle hoverColor={'#3C5A99'} activeColor={'#3C5A99'} caption="Facebook" ariaLabel="Facebook">
             <FacebookIcon />
           </StyledIconButton>
         </FacebookShareButton>
 
-        <TwitterShareButton url={url} title={sharedObjectTitle} hashtags={['wheelmap', 'accessibility', 'a11y']}>
+        <TwitterShareButton
+          url={url}
+          title={sharedObjectTitle}
+          hashtags={['wheelmap', 'accessibility', 'a11y']}
+          openWindow={false}
+          onClick={openLinkViaLocationHref}
+        >
           <StyledIconButton isHorizontal={false} hasCircle hoverColor={'#1DA1F2'} activeColor={'#1DA1F2'} caption="Twitter" ariaLabel="Twitter">
             <TwitterIcon />
           </StyledIconButton>
         </TwitterShareButton>
 
-        <TelegramShareButton url={url} title={sharedObjectTitle}>
+        <TelegramShareButton
+          url={url}
+          title={sharedObjectTitle}
+          openWindow={false}
+          onClick={openLinkViaLocationHref}
+        >
           <StyledIconButton isHorizontal={false} hasCircle hoverColor={'#7AA5DA'} activeColor={'#7AA5DA'} caption="Telegram" ariaLabel="Telegram">
             <TelegramIcon />
           </StyledIconButton>
@@ -174,7 +192,12 @@ class ExpandableShareButtons extends React.Component<Props, State> {
           </StyledIconButton>
         </a>
 
-        <WhatsappShareButton url={url} title={sharedObjectTitle}>
+        <WhatsappShareButton
+          url={url}
+          title={sharedObjectTitle}
+          openWindow={false}
+          onClick={openLinkViaLocationHref}
+        >
           <StyledIconButton isHorizontal={false} hasCircle hoverColor={'#25D366'} activeColor={'#25D366'} caption="Whatsapp" ariaLabel="Whatsapp">
             <WhatsAppIcon />
           </StyledIconButton>

--- a/src/components/NodeToolbar/IconButtonList/ShareButtons.js
+++ b/src/components/NodeToolbar/IconButtonList/ShareButtons.js
@@ -144,7 +144,14 @@ class ExpandableShareButtons extends React.Component<Props, State> {
 
     if (!this.state.isExpanded) return expandButton;
 
-    const openLinkViaLocationHref = link => window.location.href = link;
+    // The share button lib we're using is using window.open() by default which
+    // seems to not work in our Cordova app for some reason. If we are a Cordova
+    // app then we configure the share buttons to use window.location.href which
+    // works in Cordova.
+    // If we are on web we just use the default behavior of the share buttons.
+    const linkOpeningViaLocationHrefProps = window.cordova
+      ? { openWindow: false, onClick: link => (window.location.href = link) }
+      : null;
 
     return <div className={this.props.className}>
       <button ref={collapseButton => this.collapseButton = collapseButton} className={'link-button collapse-button'} onClick={() => this.toggle(false)} aria-expanded={this.state.isExpanded} aria-label={t`Collapse share menu`}>
@@ -155,8 +162,7 @@ class ExpandableShareButtons extends React.Component<Props, State> {
         <FacebookShareButton
           url={url}
           quote={pageDescription}
-          openWindow={false}
-          onClick={openLinkViaLocationHref}
+          {...linkOpeningViaLocationHrefProps}
         >
           <StyledIconButton isHorizontal={false} hasCircle hoverColor={'#3C5A99'} activeColor={'#3C5A99'} caption="Facebook" ariaLabel="Facebook">
             <FacebookIcon />
@@ -167,8 +173,7 @@ class ExpandableShareButtons extends React.Component<Props, State> {
           url={url}
           title={sharedObjectTitle}
           hashtags={['wheelmap', 'accessibility', 'a11y']}
-          openWindow={false}
-          onClick={openLinkViaLocationHref}
+          {...linkOpeningViaLocationHrefProps}
         >
           <StyledIconButton isHorizontal={false} hasCircle hoverColor={'#1DA1F2'} activeColor={'#1DA1F2'} caption="Twitter" ariaLabel="Twitter">
             <TwitterIcon />
@@ -178,8 +183,7 @@ class ExpandableShareButtons extends React.Component<Props, State> {
         <TelegramShareButton
           url={url}
           title={sharedObjectTitle}
-          openWindow={false}
-          onClick={openLinkViaLocationHref}
+          {...linkOpeningViaLocationHrefProps}
         >
           <StyledIconButton isHorizontal={false} hasCircle hoverColor={'#7AA5DA'} activeColor={'#7AA5DA'} caption="Telegram" ariaLabel="Telegram">
             <TelegramIcon />
@@ -195,8 +199,7 @@ class ExpandableShareButtons extends React.Component<Props, State> {
         <WhatsappShareButton
           url={url}
           title={sharedObjectTitle}
-          openWindow={false}
-          onClick={openLinkViaLocationHref}
+          {...linkOpeningViaLocationHrefProps}
         >
           <StyledIconButton isHorizontal={false} hasCircle hoverColor={'#25D366'} activeColor={'#25D366'} caption="Whatsapp" ariaLabel="Whatsapp">
             <WhatsAppIcon />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7636,10 +7636,6 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-platform@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.4.tgz#6f0fb17edaaa48f21442b3a975c063130f1c3ebd"
-
 plist@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-2.0.1.tgz#0a32ca9481b1c364e92e18dc55c876de9d01da8b"
@@ -8387,14 +8383,13 @@ react-scrolllock@^2.0.1:
     exenv "^1.2.2"
     react-prop-toggle "^1.0.2"
 
-react-share@^1.15.1:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/react-share/-/react-share-1.16.0.tgz#4d5da774bc982d15612bb7d42179eeeb84ca94d7"
+react-share@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-share/-/react-share-2.3.1.tgz#e07e9465b4a0a32119841e9676cab841954f27f2"
   dependencies:
     babel-runtime "^6.6.1"
     classnames "^2.2.5"
     jsonp "^0.2.1"
-    platform "^1.3.4"
     prop-types "^15.5.8"
 
 react-swipeable@^4.0.1:


### PR DESCRIPTION
This fixes a bug where the share buttons would not open anything at all. This only happened on mobile (Cordova) apps.