### PR TITLE
Fix sorting bug of accessiblity and toilet status filters.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "ua-parser-js": "^0.7.18",
     "underscore.string": "^3.3.4",
     "unfetch": "^3.0.0",
-    "wicg-focus-ring": "https://github.com/dakeyras7/focus-ring#include-enter-keydown"
+    "wicg-focus-ring": "https://github.com/dakeyras7/focus-ring#include-enter-keydown",
+    "cordova-android": "~7.0.0"
   },
   "devDependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "ua-parser-js": "^0.7.18",
     "underscore.string": "^3.3.4",
     "unfetch": "^3.0.0",
-    "wicg-focus-ring": "https://github.com/dakeyras7/focus-ring#include-enter-keydown",
-    "cordova-android": "~7.0.0"
+    "wicg-focus-ring": "https://github.com/dakeyras7/focus-ring#include-enter-keydown"
   },
   "devDependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -91,30 +91,24 @@ type State = {
   photoMarkedForReport: PhotoModel | null,
 };
 
-function getAccessibilityFilterFrom(statusString: string): YesNoLimitedUnknown[] {
-  const allowedStatuses = yesNoLimitedUnknownArray;
-
+function parseStatusString(statusString, allowedStatuses) {
   // Safe mutable sort as filter always returns a new array.
-  const result = statusString
+  return statusString
     ? statusString
         .split(/\./)
         .filter(s => includes(allowedStatuses, s))
         .sort()
     : [...allowedStatuses];
+}
+
+function getAccessibilityFilterFrom(statusString: string): YesNoLimitedUnknown[] {
+  const result = parseStatusString(statusString, yesNoLimitedUnknownArray);
 
   return ((result: any): YesNoLimitedUnknown[]);
 }
 
 function getToiletFilterFrom(toiletString: string): YesNoUnknown[] {
-  const allowedStatuses = yesNoUnknownArray;
-
-  // Safe mutable sort as filter always returns a new array.
-  const result = toiletString
-    ? toiletString
-        .split(/\./)
-        .filter(s => includes(allowedStatuses, s))
-        .sort()
-    : [...allowedStatuses];
+  const result = parseStatusString(toiletString, yesNoUnknownArray);
 
   return ((result: any): YesNoUnknown[]);
 }

--- a/src/App.js
+++ b/src/App.js
@@ -93,15 +93,25 @@ type State = {
 
 function getAccessibilityFilterFrom(statusString: string): YesNoLimitedUnknown[] {
   const allowedStatuses = yesNoLimitedUnknownArray;
-  if (!statusString) return [].concat(allowedStatuses);
-  const result = statusString.split(/\./).filter(s => includes(allowedStatuses, s));
+
+  // Safe mutable sort as we have a new array in both cases.
+  const result = (statusString
+    ? statusString.split(/\./).filter(s => includes(allowedStatuses, s))
+    : [...allowedStatuses]
+  ).sort();
+
   return ((result: any): YesNoLimitedUnknown[]);
 }
 
 function getToiletFilterFrom(toiletString: string): YesNoUnknown[] {
   const allowedStatuses = yesNoUnknownArray;
-  if (!toiletString) return [].concat(allowedStatuses);
-  const result = toiletString.split(/\./).filter(s => includes(allowedStatuses, s));
+
+  // Safe mutable sort as we have a new array in both cases.
+  const result = (toiletString
+    ? toiletString.split(/\./).filter(s => includes(allowedStatuses, s))
+    : [...allowedStatuses]
+  ).sort();
+
   return ((result: any): YesNoUnknown[]);
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -94,11 +94,13 @@ type State = {
 function getAccessibilityFilterFrom(statusString: string): YesNoLimitedUnknown[] {
   const allowedStatuses = yesNoLimitedUnknownArray;
 
-  // Safe mutable sort as we have a new array in both cases.
-  const result = (statusString
-    ? statusString.split(/\./).filter(s => includes(allowedStatuses, s))
-    : [...allowedStatuses]
-  ).sort();
+  // Safe mutable sort as filter always returns a new array.
+  const result = statusString
+    ? statusString
+        .split(/\./)
+        .filter(s => includes(allowedStatuses, s))
+        .sort()
+    : [...allowedStatuses];
 
   return ((result: any): YesNoLimitedUnknown[]);
 }
@@ -106,11 +108,13 @@ function getAccessibilityFilterFrom(statusString: string): YesNoLimitedUnknown[]
 function getToiletFilterFrom(toiletString: string): YesNoUnknown[] {
   const allowedStatuses = yesNoUnknownArray;
 
-  // Safe mutable sort as we have a new array in both cases.
-  const result = (toiletString
-    ? toiletString.split(/\./).filter(s => includes(allowedStatuses, s))
-    : [...allowedStatuses]
-  ).sort();
+  // Safe mutable sort as filter always returns a new array.
+  const result = toiletString
+    ? toiletString
+        .split(/\./)
+        .filter(s => includes(allowedStatuses, s))
+        .sort()
+    : [...allowedStatuses];
 
   return ((result: any): YesNoUnknown[]);
 }

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -370,12 +370,17 @@ export default class Map extends React.Component<Props, State> {
       this.addAttribution();
     }
 
+    // Sort is mutable. Create a new array and sort this one instead.
     const accessibilityFilterChanged = !isEqual(
-      this.props.accessibilityFilter,
-      newProps.accessibilityFilter
+      [...this.props.accessibilityFilter].sort(),
+      [...newProps.accessibilityFilter].sort()
     );
 
-    const toiletFilterChanged = !isEqual(this.props.toiletFilter, newProps.toiletFilter);
+    // Sort is mutable. Create a new array and sort this one instead.
+    const toiletFilterChanged = !isEqual(
+      [...this.props.toiletFilter].sort(),
+      [...newProps.toiletFilter].sort()
+    );
 
     if (accessibilityFilterChanged || toiletFilterChanged) {
       setTimeout(() => {

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -371,13 +371,12 @@ export default class Map extends React.Component<Props, State> {
     }
 
     const accessibilityFilterChanged = !isEqual(
-      this.props.accessibilityFilter.sort(),
-      newProps.accessibilityFilter.sort()
+      this.props.accessibilityFilter,
+      newProps.accessibilityFilter
     );
-    const toiletFilterChanged = !isEqual(
-      this.props.toiletFilter.sort(),
-      newProps.toiletFilter.sort()
-    );
+
+    const toiletFilterChanged = !isEqual(this.props.toiletFilter, newProps.toiletFilter);
+
     if (accessibilityFilterChanged || toiletFilterChanged) {
       setTimeout(() => {
         if (this.accessibilityCloudTileLayer) this.accessibilityCloudTileLayer._reset();

--- a/src/components/SearchToolbar/AccessibilityFilterMenu.js
+++ b/src/components/SearchToolbar/AccessibilityFilterMenu.js
@@ -72,7 +72,7 @@ function findFilterKey({ toiletFilter, accessibilityFilter }) {
   const availableFilters = getAvailableFilters();
   return Object.keys(availableFilters).find(key => {
     const filter = availableFilters[key];
-    const requestedToiletFilter = isEqual(toiletFilter, ['yes', 'no', 'unknown'])
+    const requestedToiletFilter = isEqual(toiletFilter, ['no', 'unknown', 'yes'])
       ? []
       : toiletFilter;
     return (
@@ -92,7 +92,7 @@ function AccessibilityFilterMenu(props: Props) {
   return (
     <section className={props.className} aria-label={t`Wheelchair accessibility filter`}>
       <section className="accessibility-filter">
-        {shownFilterKeys.map((key, index) => (
+        {shownFilterKeys.map(key => (
           <AccessibilityFilterButton
             accessibilityFilter={availableFilters[key].accessibilityFilter}
             toiletFilter={availableFilters[key].toiletFilter}

--- a/src/components/SearchToolbar/AccessibilityFilterMenu.js
+++ b/src/components/SearchToolbar/AccessibilityFilterMenu.js
@@ -9,6 +9,7 @@ import colors from '../../lib/colors';
 import AccessibilityFilterButton from './AccessibilityFilterButton';
 import type { PlaceFilter } from './AccessibilityFilterModel';
 import type { YesNoLimitedUnknown } from '../../lib/Feature';
+import { yesNoUnknownArray } from '../../lib/Feature';
 
 type Props = PlaceFilter & {
   history: RouterHistory,
@@ -72,9 +73,7 @@ function findFilterKey({ toiletFilter, accessibilityFilter }) {
   const availableFilters = getAvailableFilters();
   return Object.keys(availableFilters).find(key => {
     const filter = availableFilters[key];
-    const requestedToiletFilter = isEqual(toiletFilter, ['no', 'unknown', 'yes'])
-      ? []
-      : toiletFilter;
+    const requestedToiletFilter = isEqual(toiletFilter, yesNoUnknownArray) ? [] : toiletFilter;
     return (
       isEqual(requestedToiletFilter, filter.toiletFilter) &&
       isEqual(accessibilityFilter.sort(), filter.accessibilityFilter.sort())

--- a/src/lib/Feature.js
+++ b/src/lib/Feature.js
@@ -19,9 +19,9 @@ import type { LocalizedString } from './i18n';
 
 export type YesNoLimitedUnknown = 'yes' | 'no' | 'limited' | 'unknown';
 export type YesNoUnknown = 'yes' | 'no' | 'unknown';
-export const yesNoLimitedUnknownArray = ['yes', 'limited', 'no', 'unknown'];
+export const yesNoLimitedUnknownArray = ['yes', 'limited', 'no', 'unknown'].sort();
 Object.freeze(yesNoLimitedUnknownArray);
-export const yesNoUnknownArray = ['yes', 'no', 'unknown'];
+export const yesNoUnknownArray = ['yes', 'no', 'unknown'].sort();
 Object.freeze(yesNoUnknownArray);
 
 function sortedIsEqual(array1, array2): boolean {


### PR DESCRIPTION
The Map component was sorting status and toilet status filters when comparing arrays for equality. This sorting was mutable and changing the order of given status filters for other components too. The StatusFilter component used the equality of status filters to see if a status filter was selected by user. The changed order broke this comparison.

This PR moves the sorting of accessibility and toilet status filters to the App component (getDerivedStateFromProps) so that all components always have the sorted list of statuses.

See: https://trello.com/c/DOl6ELoV