### PR TITLE
Fix routing for 404 not found.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -201,13 +201,31 @@ class Loader extends React.Component<Props, State> {
   }
 
   static getDerivedStateFromProps(props: Props, state: State): State {
-    const routeInformation = getRouteInformation(props) || {};
+    const routeInformation = getRouteInformation(props);
+    let result: $Shape<State> = {
+      equipmentInfoId: null,
+      category: null,
+      searchQuery: null,
+      modalNodeState: null,
+      toiletFilter: [],
+      accessibilityFilter: [],
+    };
+
+    if (!routeInformation) {
+      return {
+        ...result,
+        isNotFoundVisible: true,
+        lastError: 'Route not found.',
+      };
+    }
+
     const { featureId, equipmentInfoId, category, searchQuery, modalNodeState } = routeInformation;
 
     const toiletFilter = getToiletFilterFrom(routeInformation.toilet);
     const accessibilityFilter = getAccessibilityFilterFrom(routeInformation.status);
 
-    const result: $Shape<State> = {
+    result = {
+      ...result,
       equipmentInfoId,
       // keep category if you just click on a feature
       category: featureId ? state.category || category : category,
@@ -253,14 +271,6 @@ class Loader extends React.Component<Props, State> {
     const locationState = props.history.location.state;
     if (locationState) {
       result.isOnboardingVisible = !!locationState.isOnboardingVisible;
-    }
-
-    if (!routeInformation) {
-      Object.assign(result, {
-        isNotFoundVisible: true,
-        lastError: 'Route not found.',
-      });
-      return result;
     }
 
     return result;

--- a/src/components/NotFound/NotFound.js
+++ b/src/components/NotFound/NotFound.js
@@ -126,50 +126,6 @@ const StyledNotFound = styled(NotFound)`
     display: none;
   }
 
-  /*.modal-dialog-content {
-    padding: 15px;
-    display: flex;
-    flex-direction: row;
-    overflow: auto;
-    .logo {
-      width: 200px;
-    }
-
-    @media (max-width: 768px) {
-      > header {
-        .logo {
-          width: 150px;
-        }
-      }
-    }
-
-    @media (max-width: 1199px) {
-      flex-direction: column !important;
-
-      > footer,
-      > header {
-        text-align: center;
-        width: 75%;
-        margin: 0 12.5%;
-      }
-    }
-
-    @media (min-width: 1200px) {
-      justify-content: center;
-      align-items: center;
-
-      > header,
-      > footer {
-        flex: 1;
-      }
-      > section {
-        flex: 2;
-      }
-    }
-
-    max-width: 1200px;
-  }*/
-
   .modal-dialog-content {
     border-radius: 20px;
     background-color: rgba(255, 255, 255, 0.92);
@@ -192,7 +148,7 @@ const StyledNotFound = styled(NotFound)`
       margin-left: 10px;
 
       path {
-        fill: white;
+        fill: currentColor; // @TODO Use "currentColor" for all SVG icon shapes.
       }
     }
 

--- a/src/components/NotFound/NotFound.js
+++ b/src/components/NotFound/NotFound.js
@@ -121,10 +121,12 @@ const StyledNotFound = styled(NotFound)`
   @media (max-height: 320px), (max-width: 320px) {
     font-size: 90%;
   }
+
   .close-dialog {
     display: none;
   }
-  .modal-dialog-content {
+
+  /*.modal-dialog-content {
     padding: 15px;
     display: flex;
     flex-direction: row;
@@ -132,6 +134,7 @@ const StyledNotFound = styled(NotFound)`
     .logo {
       width: 200px;
     }
+
     @media (max-width: 768px) {
       > header {
         .logo {
@@ -139,8 +142,10 @@ const StyledNotFound = styled(NotFound)`
         }
       }
     }
+
     @media (max-width: 1199px) {
       flex-direction: column !important;
+
       > footer,
       > header {
         text-align: center;
@@ -148,11 +153,13 @@ const StyledNotFound = styled(NotFound)`
         margin: 0 12.5%;
       }
     }
+
     @media (min-width: 1200px) {
       justify-content: center;
       align-items: center;
+
       > header,
-      footer {
+      > footer {
         flex: 1;
       }
       > section {
@@ -161,26 +168,37 @@ const StyledNotFound = styled(NotFound)`
     }
 
     max-width: 1200px;
+  }*/
 
-    .button-cta-close {
-      display: inline-block;
-      border: none;
-      outline: none;
-      color: white;
-      background-color: ${colors.linkColor};
-      font-size: 1.25em;
-      line-height: 1;
-      padding: 0.5em 0.75em;
-      margin: 1em;
-      cursor: pointer;
-      > svg {
-        margin-left: 10px;
-      }
+  .modal-dialog-content {
+    border-radius: 20px;
+    background-color: rgba(255, 255, 255, 0.92);
+    padding: 30px;
+  }
 
-      &.focus-ring {
-        box-shadow: 0px 0px 0px 4px ${colors.selectedColorLight};
-        transition: box-shadow 0.2s;
+  .button-cta-close {
+    display: inline-flex;
+    border: none;
+    outline: none;
+    color: white;
+    background-color: ${colors.linkColor};
+    font-size: 1.25em;
+    line-height: 1;
+    padding: 0.5em 0.75em;
+    margin-top: 1em;
+    cursor: pointer;
+
+    > svg {
+      margin-left: 10px;
+
+      path {
+        fill: white;
       }
+    }
+
+    &.focus-ring {
+      box-shadow: 0px 0px 0px 4px ${colors.selectedColorLight};
+      transition: box-shadow 0.2s;
     }
   }
 

--- a/src/lib/getRouteInformation.js
+++ b/src/lib/getRouteInformation.js
@@ -29,17 +29,22 @@ export default function getRouteInformation(props: Props): ?RouteInformation {
   const match = location.pathname.match(
     /(?:\/beta)?\/?(?:(-?\w+)(?:\/([-\w\d]+)(?:\/([-\w\d]+)(?:\/([-\w\d]+))?)?)?)?/i
   );
-  if (match) {
-    if (match[1] && !includes(allowedResourceNames, match[1])) return null;
-    return {
-      featureId: match[1] === 'nodes' && match[2] !== 'new' ? match[2] : null,
-      equipmentInfoId: match[1] === 'nodes' && match[3] === 'equipment' ? match[4] : null,
-      modalNodeState: getModalNodeState(match),
-      category: match[1] === 'categories' ? match[2] : null,
-      searchQuery: match[1] === 'search' ? parseQueryParams(location.search).q : null,
-      toilet: parseQueryParams(location.search).toilet,
-      status: parseQueryParams(location.search).status,
-    };
+
+  if (!match) {
+    return null;
   }
-  return null;
+
+  if (match[1] && !includes(allowedResourceNames, match[1])) {
+    return null;
+  }
+
+  return {
+    featureId: match[1] === 'nodes' && match[2] !== 'new' ? match[2] : null,
+    equipmentInfoId: match[1] === 'nodes' && match[3] === 'equipment' ? match[4] : null,
+    modalNodeState: getModalNodeState(match),
+    category: match[1] === 'categories' ? match[2] : null,
+    searchQuery: match[1] === 'search' ? parseQueryParams(location.search).q : null,
+    toilet: parseQueryParams(location.search).toilet,
+    status: parseQueryParams(location.search).status,
+  };
 }


### PR DESCRIPTION
The `routeInformation` is `null` when the given route does not match the URL format. Detecting a 404 based on the URL format might not be a save way of detecting a 404 but should be sufficient for a first version.

Also I think the 404 error page looks a bit broken on desktop. Not sure if I should fix this with this PR, too?

<img width="882" alt="screenshot 2018-09-13 10 48 36" src="https://user-images.githubusercontent.com/1609692/45477980-2f5b3b00-b743-11e8-90bb-222d97106784.png">
