### PR TITLE
Restore Last Selected Category When Closing Node Toolbar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -202,6 +202,7 @@ class Loader extends React.Component<Props, State> {
 
   static getDerivedStateFromProps(props: Props, state: State): State {
     const routeInformation = getRouteInformation(props);
+
     let result: $Shape<State> = {
       equipmentInfoId: null,
       category: null,
@@ -621,14 +622,11 @@ class Loader extends React.Component<Props, State> {
       if (category) {
         path += `/categories/${category}`;
       }
-
-      const params = getQueryParams();
-
-      path += `?${queryString.stringify(params)}`;
     }
 
-    this.props.history.push(path);
-    // this.setState({ modalNodeState: null });
+    const params = getQueryParams();
+    const location = `${path}?${queryString.stringify(params)}`;
+    this.props.history.push(location);
   };
 
   onCloseOnboarding = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -606,27 +606,35 @@ class Loader extends React.Component<Props, State> {
 
   onOpenReportMode = () => {
     if (this.state.featureId) {
-      this.props.history.push(`/beta/nodes/${String(this.state.featureId)}/report`);
+      const query = queryString.stringify(getQueryParams());
+      this.props.history.push(`/beta/nodes/${String(this.state.featureId)}/report?${query}`);
     }
   };
 
   onCloseNodeToolbar = () => {
-    const { featureId, category } = this.state;
-    let path;
+    const { category, featureId } = this.state;
 
-    if (featureId) {
-      path = `/beta/nodes/${String(this.state.featureId)}`;
-    } else {
-      path = '/beta';
+    // onCloseNodeToolbar is used as a callback for when the node toolbar is closed as well as
+    // when any node toolbar subpages are closed. in order to know how to change the route correctly
+    // we have to distinguish between these two cases
+    const actualNodeToolbarWasClosed = featureId && typeof this.modalNodeState() === 'undefined';
+    const nodeToolbarSubpageWasClosed = featureId && typeof this.modalNodeState() !== 'undefined';
 
-      if (category) {
-        path += `/categories/${category}`;
-      }
+    // by default route to the index page
+    let path = '/beta';
+
+    if (actualNodeToolbarWasClosed && category) {
+      // if node toolbar was closed and category was previously selected restore the categories url
+      path = `/beta/categories/${category}`;
+    } else if (nodeToolbarSubpageWasClosed) {
+      // if a node toolbar subpage was closed restore the node toolbar default url
+      path = `/beta/nodes/${String(featureId)}`;
     }
 
-    const params = getQueryParams();
-    const location = `${path}?${queryString.stringify(params)}`;
-    this.props.history.push(location);
+    // restore any query params
+    const query = queryString.stringify(getQueryParams());
+
+    this.props.history.push(`${path}?${query}`);
   };
 
   onCloseOnboarding = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -660,13 +660,19 @@ class Loader extends React.Component<Props, State> {
 
   onOpenWheelchairAccessibility = () => {
     if (this.state.featureId) {
-      this.props.history.push(`/beta/nodes/${this.state.featureId}/edit-wheelchair-accessibility`);
+      const query = queryString.stringify(getQueryParams());
+      this.props.history.push(
+        `/beta/nodes/${this.state.featureId}/edit-wheelchair-accessibility?${query}`
+      );
     }
   };
 
   onOpenToiletAccessibility = () => {
     if (this.state.featureId) {
-      this.props.history.push(`/beta/nodes/${this.state.featureId}/edit-toilet-accessibility`);
+      const query = queryString.stringify(getQueryParams());
+      this.props.history.push(
+        `/beta/nodes/${this.state.featureId}/edit-toilet-accessibility?${query}`
+      );
     }
   };
 

--- a/src/components/CloseLink.js
+++ b/src/components/CloseLink.js
@@ -24,13 +24,13 @@ type Props = {
 
 class CloseLink extends React.Component<Props> {
   onClick = event => {
+    event.preventDefault();
+    event.stopPropagation();
+
     if (this.props.onClick) {
       this.props.onClick(event);
       return;
     }
-
-    event.preventDefault();
-    event.stopPropagation();
 
     const params = getQueryParams();
     this.props.history.push({ pathname: '/beta', search: queryString.stringify(params) });

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -332,7 +332,7 @@ class NodeToolbar extends React.Component<Props, State> {
 
   renderCloseLink() {
     const { history, onClose, modalNodeState } = this.props;
-    return modalNodeState ? null : <PositionedCloseLink {...{ history, onClose }} />;
+    return modalNodeState ? null : <PositionedCloseLink {...{ history, onClick: onClose }} />;
   }
 
   render() {


### PR DESCRIPTION
How things were before the fix:

* Generally the selected category is fetched from the URL and passed down the component tree
* Except for when the URL contains a feature id (i.e. the NodeToolbar is open). Then we keep the previously selected category in the app state and pass that down the component tree.
* If then the NodeToolbar is closed again, we don't properly restore the previously selected category into the URL again. We instead change the URL to '/beta', so that any subsequent renders, will eventually clear out any previously selected category

After the fix:

The fix now restores the correct URL containing a previously selected category when the NodeToolbar is closed.