### PR TITLE
Fix Geolocation Error Button Being Behind Safari Toolbar

### DIFF
--- a/src/components/Map/NotificationButton.js
+++ b/src/components/Map/NotificationButton.js
@@ -109,6 +109,7 @@ const StyledNotificationButton = styled(NotificationButton)`
 
   @media (max-width: 500px), (max-height: 500px) {
     /* On small viewports, move button down to make space for category view */
+    position: fixed;
     max-width: 150px;
     top: unset;
     right: unset;

--- a/src/components/Map/NotificationButton.js
+++ b/src/components/Map/NotificationButton.js
@@ -44,7 +44,7 @@ const StyledNotificationButton = styled(NotificationButton)`
   position: absolute;
   right: 70px;
   top: ${props => props.topPosition}px;
-  max-width: 120px; /* Ensure the block does not overlap the search bar */
+  max-width: 130px; /* Ensure the block does not overlap the search bar */
   z-index: 1000;
   border-radius: 4px;
   box-shadow: 0 3px 5px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
Very small one.

Also fixed the german translations for this button overflowing the button width.

Would love to still test this with Browser Stack on Android devices etc.