### PR TITLE
WIP: Fix compiler warnings

### DIFF
--- a/src/components/CreatePlaceDialog/CreatePlaceDialog.js
+++ b/src/components/CreatePlaceDialog/CreatePlaceDialog.js
@@ -150,7 +150,7 @@ export default class CreatePlaceDialog extends React.Component<Props> {
   renderAppLinkListElements() {
     return this.appLinks().map(link => (
       <li key={link.title}>
-        <a className="link-button" href={link.href} target="_blank">
+        <a className="link-button" href={link.href} target="_blank" rel="noopener noreferrer">
           <AppIcon src={link.icon} alt="" aria-hidden />
           <span>{link.title}</span>
           <ChevronRight color={colors.linkColor} />
@@ -183,6 +183,7 @@ export default class CreatePlaceDialog extends React.Component<Props> {
             className="link-button leave-note-button"
             href={generateOsmNoteUrlForCoords({ lat, lon })}
             target="_blank"
+            rel="noopener noreferrer"
           >
             <span>{leaveANoteCaption}</span>
             <ChevronRight color={colors.linkColor} />

--- a/src/components/NodeToolbar/IconButtonList/PlaceAddress.js
+++ b/src/components/NodeToolbar/IconButtonList/PlaceAddress.js
@@ -57,7 +57,7 @@ export default class PlaceAddress extends React.Component<Props, void> {
           </a>
         )}
         {showOnOsmUrl && (
-          <a className="link-button" href={showOnOsmUrl} target="_blank">
+          <a className="link-button" href={showOnOsmUrl} target="_blank" rel="noopener noreferrer">
             <PlaceIcon />
             <span>{openButtonCaption('OpenStreetMap')}</span>
           </a>

--- a/src/components/NodeToolbar/Photos/PhotoSection.js
+++ b/src/components/NodeToolbar/Photos/PhotoSection.js
@@ -18,7 +18,6 @@ import type { PhotoModel } from './PhotoModel';
 
 import PhotoUploadButton from '../../PhotoUpload/PhotoUploadButton';
 import PhotoNotification from '../../NodeToolbar/Photos/PhotoNotification';
-import colors from '../../../lib/colors';
 
 type Props = {
   featureId: string,


### PR DESCRIPTION
This PR might need very thorough reviews as it changes the usage of state and props dramatically due to the react/no-deprecated warning deprecating [`componentWillReceiveProps`](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops).

The difficult part (at least for me learning something new about the project structure every day) is the how `componentWillReceiveProps` is used in most of the cases. While used for fetching data it also often changes the state before the component is rendered without triggering a loop of rerendering the component. As we cannot simply change the state in `componentDidUpdate` without risking a rerender loop one need to combine it with `getDerivedStateFromProps`. I think pair programming (with @opyh or @mutaphysis) might help to get a safe solution more quickly.

Affected Components:

* [x] RadioStatusEditor
* [ ] Map
* [ ] AccessibilitySourceDisclaimer
* [ ] BreadCrumbs
* [ ] EquipmentOverview
* [ ] ShareButton
* [ ] LicenseHint
* [ ] NodeToolbarFeatureLoader
* [ ] PhotoNotifcation
* [ ] PhotoSection
* [ ] FixOnExternalPage
* [ ] ReportDialog
* [ ] SourceLink
* [ ] PhotoUploadCaptchaToolbar
* [ ] SearchResult
* [ ] Toolbar