### PR TITLE
Use central category resolution also for search results

### DIFF
--- a/src/MainView.js
+++ b/src/MainView.js
@@ -256,6 +256,7 @@ class MainView extends React.Component<Props, State> {
       <SearchToolbar
         ref={searchToolbar => (this.searchToolbar = searchToolbar)}
         history={this.props.history}
+        categories={this.props.categories}
         hidden={!this.props.isSearchBarVisible}
         inert={isInert}
         category={category}

--- a/src/app/SearchData.js
+++ b/src/app/SearchData.js
@@ -87,8 +87,9 @@ const SearchData: DataTableEntry<SearchProps> = {
     let { searchResults } = props;
 
     searchResults = Promise.resolve(searchResults).then(async results => {
+      const useCache = !isServer;
       let wheelmapFeatures: Promise<?WheelmapFeature>[] = results.features.map(feature =>
-        fetchWheelmapNode(feature.properties, isServer)
+        fetchWheelmapNode(feature.properties, useCache)
       );
 
       // Fetch all wheelmap features when on server.

--- a/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
+++ b/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
@@ -89,10 +89,7 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
 
     // resolve lightweight categories
     if (props.lightweightFeature) {
-      categories = NodeToolbarFeatureLoader.getCategoriesForFeature(
-        props.categories,
-        props.lightweightFeature
-      );
+      categories = Categories.getCategoriesForFeature(props.categories, props.lightweightFeature);
     }
 
     // wait for new data

--- a/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
+++ b/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
@@ -69,7 +69,7 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
 
     // use resolved data
     if (resolvedPlaceData) {
-      const resolvedCategories = NodeToolbarFeatureLoader.getCategoriesForFeature(
+      const resolvedCategories = Categories.getCategoriesForFeature(
         props.categories,
         resolvedPlaceData.equipmentInfo || resolvedPlaceData.feature
       );
@@ -128,7 +128,7 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
     const resolvedPlaceDetails = getPlaceDetailsIfAlreadyResolved(props);
 
     if (resolvedPlaceDetails) {
-      const resolvedCategories = NodeToolbarFeatureLoader.getCategoriesForFeature(
+      const resolvedCategories = Categories.getCategoriesForFeature(
         props.categories,
         resolvedPlaceDetails.equipmentInfo || resolvedPlaceDetails.feature
       );
@@ -136,40 +136,13 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
     } else {
       this.setState({ resolvedPlaceDetails: null });
       awaitPlaceDetails(this.props).then(resolved => {
-        const resolvedCategories = NodeToolbarFeatureLoader.getCategoriesForFeature(
+        const resolvedCategories = Categories.getCategoriesForFeature(
           props.categories,
           resolved.equipmentInfo || resolved.feature
         );
         this.setState({ resolvedPlaceDetails: resolved, ...resolvedCategories });
       });
     }
-  }
-
-  // TODO move to helper
-  static getCategoriesForFeature(
-    categories: CategoryLookupTables,
-    feature: ?Feature | ?EquipmentInfo
-  ): { category: ?Category, parentCategory?: Category } {
-    if (!feature) {
-      return { category: null };
-    }
-
-    const properties = feature.properties;
-    if (!properties) {
-      return { category: null };
-    }
-
-    const categoryId =
-      (properties.node_type && properties.node_type.identifier) || properties.category;
-
-    if (!categoryId) {
-      return { category: null };
-    }
-
-    const category = Categories.getCategory(categories, categoryId);
-    const parentCategory = category && Categories.getCategory(categories, category.parentIds[0]);
-
-    return { category, parentCategory };
   }
 
   render() {

--- a/src/components/SearchToolbar/SearchResult.js
+++ b/src/components/SearchToolbar/SearchResult.js
@@ -52,7 +52,7 @@ export default class SearchResult extends React.Component<Props, State> {
     wheelmapFeaturePromise: null,
   };
 
-  root: ?React.ElementRef<'a'> = null;
+  root: ?React.ElementRef<'li'> = null;
 
   static getDerivedStateFromProps(props: Props, state: State): $Shape<State> {
     const { wheelmapFeature } = props;

--- a/src/components/SearchToolbar/SearchResults.js
+++ b/src/components/SearchToolbar/SearchResults.js
@@ -4,16 +4,16 @@ import { t } from 'ttag';
 import * as React from 'react';
 import styled from 'styled-components';
 
-import type { RouterHistory } from 'react-router-dom';
 import type { SearchResultCollection } from '../../lib/searchPlaces';
 import colors from '../../lib/colors';
 import type { SearchResultFeature } from '../../lib/searchPlaces';
 import type { WheelmapFeature } from '../../lib/Feature';
 import SearchResult from './SearchResult';
+import { type CategoryLookupTables } from '../../lib/Categories';
 
 type Props = {
   searchResults: SearchResultCollection,
-  history: RouterHistory,
+  categories: CategoryLookupTables,
   className: string,
   hidden: ?boolean,
   onSearchResultClick: (feature: SearchResultFeature, wheelmapFeature: ?WheelmapFeature) => void,
@@ -55,7 +55,7 @@ function SearchResults(props: Props) {
             key={featureId}
             onClick={props.onSearchResultClick}
             hidden={!!props.hidden}
-            history={props.history}
+            categories={props.categories}
             ref={ref => {
               if (props.refFirst && index === 0) props.refFirst(ref);
             }}

--- a/src/components/SearchToolbar/SearchToolbar.js
+++ b/src/components/SearchToolbar/SearchToolbar.js
@@ -47,6 +47,7 @@ function handleInputCommands(history: RouterHistory, commandLine: ?string) {
 
 export type Props = PlaceFilter & {
   history: RouterHistory,
+  categories: CategoryLookupTables,
   hidden: boolean,
   inert: boolean,
   category: ?string,
@@ -388,7 +389,7 @@ export default class SearchToolbar extends React.PureComponent<Props, State> {
           searchResults={searchResults}
           onSearchResultClick={this.props.onSearchResultClick}
           hidden={this.props.hidden}
-          history={this.props.history}
+          categories={this.props.categories}
           onSelect={() => this.clearSearch()}
           refFirst={ref => {
             this.firstResult = ref;


### PR DESCRIPTION
- Moved code from NodeToolbarFeatureLoader into Categories
 - Extended to support search results
 - Determine categories from search result or wheelmap result
 - Fixed a few more flow errors
 - Fixed cache usage in search results