### PR TITLE
Add redirects for homepage (/map) and legacy urls.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -12,8 +12,13 @@ app.prepare().then(() => {
   const server = express();
 
   // Old urls from the classic rails app
+  // First capturing group represents optional locale
   server.get(
-    [/([a-zA-Z_-]*)\/map\/.+/, /([a-zA-Z_-]*)\/community_support\/new.*/, /([a-zA-Z_-]*)\/embed.*/],
+    [
+      /(\/[a-zA-Z_-]+)?\/map\/.+/,
+      /(\/[a-zA-Z_-]+)?\/community_support\/new.*/,
+      /(\/[a-zA-Z_-]+)?\/embed.*/,
+    ],
     (req, res) => {
       res.redirect(`https://classic.wheelmap.org${req.originalUrl}`);
     }

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,20 @@ const handle = app.getRequestHandler();
 app.prepare().then(() => {
   const server = express();
 
+  // Old urls from the classic rails app
+  server.get(
+    [/([a-zA-Z_-]*)\/map\/.+/, /([a-zA-Z_-]*)\/community_support\/new.*/, /([a-zA-Z_-]*)\/embed.*/],
+    (req, res) => {
+      res.redirect(`https://classic.wheelmap.org${req.originalUrl}`);
+    }
+  );
+
+  server.get('/:lang?/map', (req, res) => {
+    const lang = req.param('lang');
+
+    res.redirect(`/${lang ? `?locale=${lang}` : ''}`);
+  });
+
   server.get('*', (req, res, next) => {
     const match = router.match(req.path);
 


### PR DESCRIPTION
Redirects to classic.wheelmap.org:

* `/community_support/new`
* `/map/japan/post_office/wheelchair/yes`
* `/embed`

Redirects `/map` to homepage (`/`).
Routes for `/search` and `/nodes` match the current path. 

@opyh @mutaphysis what about `/en/nodes`, etc.?