### PR TITLE
Fix search toolbar visibility and focus state on desktop.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -131,7 +131,7 @@ class App extends React.Component<Props, State> {
   static getDerivedStateFromProps(props: Props): $Shape<State> {
     const state = {
       isSearchToolbarExpanded: false,
-      isSearchBarVisible: false,
+      isSearchBarVisible: isStickySearchBarSupported(),
     };
 
     // close search results when leaving search route
@@ -141,7 +141,13 @@ class App extends React.Component<Props, State> {
     }
 
     if (props.routeName === 'place_detail') {
-      state.isSearchBarVisible = false;
+      const { accessibilityFilter, toiletFilter, category } = props;
+
+      state.isSearchBarVisible =
+        isStickySearchBarSupported() &&
+        !isAccessibilityFiltered(accessibilityFilter) &&
+        !isToiletFiltered(toiletFilter) &&
+        !category;
     }
 
     return state;
@@ -158,10 +164,12 @@ class App extends React.Component<Props, State> {
   componentDidMount() {
     if (isFirstStart()) {
       this.setState({ isOnboardingVisible: true });
+    } else if (this.props.routeName === 'map') {
+      this.openSearch(true);
     }
   }
 
-  openSearch() {
+  openSearch(replace: boolean = false) {
     if (this.props.routeName === 'search') {
       return;
     }
@@ -171,7 +179,12 @@ class App extends React.Component<Props, State> {
     delete params.id;
     delete params.eid;
 
-    this.props.routerHistory.push('search', params);
+    if (replace) {
+      this.props.routerHistory.replace('search', params);
+    } else {
+      this.props.routerHistory.push('search', params);
+    }
+
     if (this.mainView) this.mainView.focusSearchToolbar();
   }
 


### PR DESCRIPTION
This PR contains:

* A fix for https://trello.com/c/FXRjwbrE: redirect App when mounted and started with `map` route to `search` so that the `SearchToolbar` is expanded and focused.
* A fix for https://trello.com/c/x63jlVOo: Show search toolbar search field when on possible (desktop and no active place detail page with active category or accessibility filters)