### PR TITLE
Respect exclude & includeSourceIds

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -64,8 +64,11 @@ type Props = {
   lon: ?string,
   zoom: ?string,
   extent: ?[number, number, number, number],
-  includeSourceIds: ?string,
+
+  includeSourceIds: Array<string>,
+  excludeSourceIds: Array<string>,
   disableWheelmapSource?: boolean,
+
   toiletFilter: YesNoUnknown[],
   accessibilityFilter: YesNoLimitedUnknown[],
 } & PlaceDetailsProps;
@@ -422,6 +425,8 @@ class App extends React.Component<Props, State> {
       equipmentInfoId,
       disableWheelmapSource,
       includeSourceIds,
+      excludeSourceIds,
+      clientSideConfiguration,
     } = this.props;
 
     if (category) {
@@ -445,8 +450,18 @@ class App extends React.Component<Props, State> {
     }
 
     // ensure to keep widget/custom whitelabel parameters
-    if (includeSourceIds) {
-      params.includeSourceIds = includeSourceIds;
+    if (includeSourceIds && includeSourceIds.length > 0) {
+      const includeSourceIdsAsString = includeSourceIds.join(',');
+      if (includeSourceIdsAsString !== clientSideConfiguration.includeSourceIds.join(',')) {
+        params.includeSourceIds = includeSourceIdsAsString;
+      }
+    }
+
+    if (excludeSourceIds && excludeSourceIds.length > 0) {
+      const excludeSourceIdsAsString = excludeSourceIds.join(',');
+      if (excludeSourceIdsAsString !== clientSideConfiguration.excludeSourceIds.join(',')) {
+        params.excludeSourceIds = excludeSourceIdsAsString;
+      }
     }
 
     if (disableWheelmapSource) {
@@ -615,6 +630,7 @@ class App extends React.Component<Props, State> {
 
       disableWheelmapSource: this.props.disableWheelmapSource,
       includeSourceIds: this.props.includeSourceIds,
+      excludeSourceIds: this.props.excludeSourceIds,
 
       // photo feature
       isPhotoUploadCaptchaToolbarVisible:

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -60,10 +60,11 @@ type Props = {
   zoom: ?number,
   extent: ?[number, number, number, number],
 
-  includeSourceIds: ?string,
+  includeSourceIds: Array<string>,
+  excludeSourceIds: Array<string>,
   disableWheelmapSource: ?boolean,
-  isReportMode: ?boolean,
 
+  isReportMode: ?boolean,
   isOnboardingVisible: boolean,
   isMainMenuOpen: boolean,
   isNotFoundVisible: boolean,
@@ -486,6 +487,7 @@ class MainView extends React.Component<Props, State> {
         zoom={zoom ? parseFloat(zoom) : null}
         extent={this.props.extent}
         includeSourceIds={this.props.includeSourceIds}
+        excludeSourceIds={this.props.excludeSourceIds}
         disableWheelmapSource={this.props.disableWheelmapSource}
         category={category}
         feature={this.props.lightweightFeature || this.props.feature}

--- a/src/app/getInitialProps.js
+++ b/src/app/getInitialProps.js
@@ -34,6 +34,10 @@ export type AppProps = {
   disableWheelmapSource?: boolean,
   isCordovaBuild?: boolean,
   skipApplicationBody?: boolean,
+
+  includeSourceIds: Array<string>,
+  excludeSourceIds: Array<string>,
+  disableWheelmapSource?: boolean,
 };
 
 type DataTableQuery = {
@@ -101,7 +105,9 @@ export async function getAppInitialProps(
     toilet,
     q,
     includeSourceIds,
+    excludeSourceIds,
     disableWheelmapSource,
+
     ...query
   }: {
     userAgentString: string,
@@ -115,6 +121,7 @@ export async function getAppInitialProps(
     accessibility?: string,
     toilet?: string,
     includeSourceIds?: string,
+    excludeSourceIds?: string,
     disableWheelmapSource?: string,
     [key: string]: string,
   },
@@ -167,6 +174,13 @@ export async function getAppInitialProps(
   const accessibilityFilter = getAccessibilityFilterFrom(accessibility);
   const toiletFilter = getToiletFilterFrom(toilet);
 
+  const includeSourceIdsArray =
+    (includeSourceIds ? includeSourceIds.split(/,/) : null) ||
+    (clientSideConfiguration ? clientSideConfiguration.includeSourceIds : []);
+  const excludeSourceIdsArray =
+    (excludeSourceIds ? excludeSourceIds.split(/,/) : null) ||
+    (clientSideConfiguration ? clientSideConfiguration.excludeSourceIds : []);
+
   // assign to local variable for better flow errors
   const appProps: AppProps = {
     userAgent,
@@ -182,7 +196,9 @@ export async function getAppInitialProps(
     accessibilityFilter,
     toiletFilter,
     searchQuery: q,
-    includeSourceIds,
+
+    includeSourceIds: includeSourceIdsArray,
+    excludeSourceIds: excludeSourceIdsArray,
     disableWheelmapSource: disableWheelmapSource === 'true',
   };
   return appProps;

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -82,7 +82,8 @@ type Props = {
   zoom?: ?number,
   extent: ?[number, number, number, number],
 
-  includeSourceIds: ?string,
+  includeSourceIds: Array<string>,
+  excludeSourceIds: Array<string>,
   disableWheelmapSource: ?boolean,
 
   onMarkerClick: (featureId: string, properties: ?NodeProperties) => void,
@@ -456,7 +457,11 @@ export default class Map extends React.Component<Props, State> {
     if (!locale) {
       console.error('Could not load AC tile layer because no current locale is set.');
     }
-    const tileUrl = getAccessibilityCloudTileUrl(locale, this.props.includeSourceIds);
+    const tileUrl = getAccessibilityCloudTileUrl(
+      locale,
+      this.props.includeSourceIds,
+      this.props.excludeSourceIds
+    );
 
     this.accessibilityCloudTileLayer = new GeoJSONTileLayer(tileUrl, {
       featureCache: accessibilityCloudFeatureCache,

--- a/src/components/Map/getAccessibilityCloudTileUrl.js
+++ b/src/components/Map/getAccessibilityCloudTileUrl.js
@@ -5,14 +5,26 @@ import { type Locale } from '../../lib/i18n';
 
 export default function accessibilityCloudTileUrl(
   locale: Locale,
-  includeSourceIds: ?string
+  includeSourceIds: Array<string>,
+  excludeSourceIds: Array<string>
 ): string {
   const acLocaleString = locale.underscoredString;
 
-  let sourceIdParams = 'excludeSourceIds=LiBTS67TjmBcXdEmX'; // Do not show Wheelmap's AC source
-  if (includeSourceIds) {
-    sourceIdParams = `includeSourceIds=${includeSourceIds}`;
+  // always do not show wheelmap source, but all other sources
+  const wheelmapSourceId = 'LiBTS67TjmBcXdEmX';
+
+  let sourceIdParams = '';
+  // exclude > include > defaults
+  if (excludeSourceIds) {
+    sourceIdParams = `excludeSourceIds=${[wheelmapSourceId, ...excludeSourceIds].join(',')}`;
+  } else if (includeSourceIds) {
+    sourceIdParams = `includeSourceIds=${includeSourceIds.join(
+      ','
+    )}&excludeSourceIds=${wheelmapSourceId}`;
+  } else {
+    sourceIdParams = `excludeSourceIds=${wheelmapSourceId}`;
   }
+
   return `${
     env.public.accessibilityCloud.baseUrl.cached
   }/place-infos.json?${sourceIdParams}&x={x}&y={y}&z={z}&appToken=${


### PR DESCRIPTION
- Added excludeSourceIds
 - Use exclude & include source ids as Array<string>
 - Respect exclude & include source ids from client config
 - Ensure exclude & include are correctly preserved only when
   the are different than the config & non empty

Test with eg. http://localhost:3000/search?disableWheelmapSource=true&excludeSourceIds=QxyZ7vAMS695Bhvii
