### PR TITLE
Improve Next.js Custom Code + MainView code

### DIFF
--- a/src/MainView.js
+++ b/src/MainView.js
@@ -213,14 +213,14 @@ class MainView extends React.Component<Props, State> {
     }
   };
 
-  renderNodeToolbar(
-    { featureId, equipmentInfoId, modalNodeState, accessibilityPresetStatus }: $Shape<Props>,
-    isNodeRoute: boolean
-  ) {
+  renderNodeToolbar(isNodeRoute: boolean) {
     return (
       <div className="node-toolbar">
         <NodeToolbarFeatureLoader
-          {...{ featureId, equipmentInfoId, modalNodeState, accessibilityPresetStatus }}
+          featureId={this.props.featureId}
+          equipmentInfoId={this.props.equipmentInfoId}
+          modalNodeState={this.props.modalNodeState}
+          accessibilityPresetStatus={this.props.accessibilityPresetStatus}
           ref={nodeToolbar => (this.nodeToolbar = nodeToolbar)}
           lightweightFeature={this.props.lightweightFeature}
           feature={this.props.feature}
@@ -249,20 +249,17 @@ class MainView extends React.Component<Props, State> {
     );
   }
 
-  renderSearchToolbar(
-    { category, searchQuery, searchResults, disableWheelmapSource }: $Shape<Props>,
-    isInert: boolean
-  ) {
+  renderSearchToolbar(isInert: boolean) {
     return (
       <SearchToolbar
         ref={searchToolbar => (this.searchToolbar = searchToolbar)}
         categories={this.props.categories}
         hidden={!this.props.isSearchBarVisible}
         inert={isInert}
-        category={category}
-        showCategoryMenu={!disableWheelmapSource}
-        searchQuery={searchQuery}
-        searchResults={searchResults}
+        category={this.props.category}
+        showCategoryMenu={!this.props.disableWheelmapSource}
+        searchQuery={this.props.searchQuery}
+        searchResults={this.props.searchResults}
         accessibilityFilter={this.props.accessibilityFilter}
         toiletFilter={this.props.toiletFilter}
         onChangeSearchQuery={this.props.onSearchQueryChange}
@@ -309,29 +306,29 @@ class MainView extends React.Component<Props, State> {
     );
   }
 
-  renderMainMenu({ isLocalizationLoaded, lat, lon, zoom }: $Shape<Props>) {
+  renderMainMenu() {
     const {
-      isMainMenuOpen,
-      onMainMenuHomeClick,
-      onToggleMainMenu,
-      clientSideConfiguration,
-    } = this.props;
-
-    const { logoURL, customMainMenuLinks, addPlaceURL, textContent } = clientSideConfiguration;
+      logoURL,
+      customMainMenuLinks,
+      addPlaceURL,
+      textContent,
+    } = this.props.clientSideConfiguration;
 
     return (
       <MainMenu
         className="main-menu"
-        isOpen={isMainMenuOpen}
-        onToggle={onToggleMainMenu}
-        onHomeClick={onMainMenuHomeClick}
-        isLocalizationLoaded={isLocalizationLoaded}
+        isOpen={this.props.isMainMenuOpen}
+        onToggle={this.props.onToggleMainMenu}
+        onHomeClick={this.props.onMainMenuHomeClick}
+        isLocalizationLoaded={this.props.isLocalizationLoaded}
         onAddMissingPlaceClick={this.props.onAddMissingPlaceClick}
         logoURL={logoURL}
         claim={textContent.product.claim}
         links={customMainMenuLinks}
         addPlaceURL={addPlaceURL}
-        {...{ lat, lon, zoom }}
+        lat={this.props.lat}
+        lon={this.props.lon}
+        zoom={this.props.zoom}
       />
     );
   }
@@ -470,12 +467,6 @@ class MainView extends React.Component<Props, State> {
   render() {
     const {
       featureId,
-      searchQuery,
-      equipmentInfoId,
-      accessibilityPresetStatus,
-      searchResults,
-      disableWheelmapSource,
-      category,
       className,
       isOnboardingVisible,
       isNotFoundVisible,
@@ -483,9 +474,6 @@ class MainView extends React.Component<Props, State> {
       isSearchBarVisible,
       isSearchButtonVisible,
       isNodeToolbarDisplayed: isNodeToolbarVisible,
-      lat,
-      lon,
-      zoom,
       modalNodeState,
       isPhotoUploadCaptchaToolbarVisible,
       isPhotoUploadInstructionsToolbarVisible,
@@ -520,28 +508,19 @@ class MainView extends React.Component<Props, State> {
 
     const searchToolbarIsInert: boolean = searchToolbarIsHidden || isMainMenuOpen;
 
-    const mainMenu = this.renderMainMenu({ modalNodeState, lat, lon, zoom });
-    const nodeToolbar = this.renderNodeToolbar(
-      { featureId, equipmentInfoId, modalNodeState, accessibilityPresetStatus },
-      isNodeRoute
-    );
-
     return (
       <div className={classList.join(' ')}>
-        {!isMainMenuInBackground && mainMenu}
+        {!isMainMenuInBackground && this.renderMainMenu()}
         <ErrorBoundary>
           <div className="behind-backdrop">
-            {isMainMenuInBackground && mainMenu}
-            {this.renderSearchToolbar(
-              { category, searchQuery, searchResults, disableWheelmapSource },
-              searchToolbarIsInert
-            )}
-            {isNodeToolbarVisible && !modalNodeState && nodeToolbar}
+            {isMainMenuInBackground && this.renderMainMenu()}
+            {this.renderSearchToolbar(searchToolbarIsInert)}
+            {isNodeToolbarVisible && !modalNodeState && this.renderNodeToolbar(isNodeRoute)}
             {isSearchButtonVisible && this.renderSearchButton()}
             {this.renderMap()}
           </div>
           {this.renderFullscreenBackdrop()}
-          {isNodeToolbarVisible && modalNodeState && nodeToolbar}
+          {isNodeToolbarVisible && modalNodeState && this.renderNodeToolbar(isNodeRoute)}
           {isPhotoUploadCaptchaToolbarVisible && this.renderPhotoUploadCaptchaToolbar()}
           {isPhotoUploadInstructionsToolbarVisible && this.renderPhotoUploadInstructionsToolbar()}
           {photoMarkedForReport && this.renderReportPhotoToolbar()}

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -184,10 +184,6 @@ class MainView extends React.Component<Props, State> {
     this.resizeListener();
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    // this.manageFocus(prevProps, prevState);
-  }
-
   componentWillUnmount() {
     delete this.resizeListener;
     if (typeof window !== 'undefined') {
@@ -202,12 +198,6 @@ class MainView extends React.Component<Props, State> {
   focusSearchToolbar() {
     if (this.searchToolbar) {
       this.searchToolbar.focus();
-    }
-  }
-
-  focusNodeToolbar() {
-    if (this.nodeToolbar) {
-      this.nodeToolbar.focus();
     }
   }
 

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -419,6 +419,54 @@ class MainView extends React.Component<Props, State> {
     );
   }
 
+  renderMap() {
+    const {
+      lat,
+      lon,
+      zoom,
+      category,
+      featureId,
+      equipmentInfoId,
+      isNodeToolbarDisplayed: isNodeToolbarVisible,
+    } = this.props;
+    return (
+      <DynamicMap
+        forwardedRef={map => {
+          this.map = map;
+          if (typeof window !== 'undefined') {
+            window.map = map;
+          }
+        }}
+        onMoveEnd={this.props.onMoveEnd}
+        onClick={this.props.onMapClick}
+        onMarkerClick={this.props.onMarkerClick}
+        hrefForFeature={hrefForFeature}
+        onError={this.props.onError}
+        lat={lat ? parseFloat(lat) : null}
+        lon={lon ? parseFloat(lon) : null}
+        zoom={zoom ? parseFloat(zoom) : null}
+        extent={this.props.extent}
+        includeSourceIds={this.props.includeSourceIds}
+        excludeSourceIds={this.props.excludeSourceIds}
+        disableWheelmapSource={this.props.disableWheelmapSource}
+        category={category}
+        feature={this.props.lightweightFeature || this.props.feature}
+        featureId={featureId}
+        equipmentInfo={this.props.equipmentInfo}
+        equipmentInfoId={equipmentInfoId}
+        categories={this.props.categories}
+        accessibilityFilter={this.props.accessibilityFilter}
+        toiletFilter={this.props.toiletFilter}
+        locateOnStart={this.props.shouldLocateOnStart}
+        padding={this.getMapPadding()}
+        hideHints={
+          this.state.isOnSmallViewport && (isNodeToolbarVisible || this.props.isMainMenuOpen)
+        }
+        {...config}
+      />
+    );
+  }
+
   render() {
     const {
       featureId,
@@ -459,43 +507,6 @@ class MainView extends React.Component<Props, State> {
 
     const searchToolbarIsInert: boolean = searchToolbarIsHidden || this.props.isMainMenuOpen;
 
-    const map = (
-      <DynamicMap
-        forwardedRef={map => {
-          this.map = map;
-          if (typeof window !== 'undefined') {
-            window.map = map;
-          }
-        }}
-        onMoveEnd={this.props.onMoveEnd}
-        onClick={this.props.onMapClick}
-        onMarkerClick={this.props.onMarkerClick}
-        hrefForFeature={hrefForFeature}
-        onError={this.props.onError}
-        lat={lat ? parseFloat(lat) : null}
-        lon={lon ? parseFloat(lon) : null}
-        zoom={zoom ? parseFloat(zoom) : null}
-        extent={this.props.extent}
-        includeSourceIds={this.props.includeSourceIds}
-        excludeSourceIds={this.props.excludeSourceIds}
-        disableWheelmapSource={this.props.disableWheelmapSource}
-        category={category}
-        feature={this.props.lightweightFeature || this.props.feature}
-        featureId={featureId}
-        equipmentInfo={this.props.equipmentInfo}
-        equipmentInfoId={equipmentInfoId}
-        categories={this.props.categories}
-        accessibilityFilter={this.props.accessibilityFilter}
-        toiletFilter={this.props.toiletFilter}
-        locateOnStart={this.props.shouldLocateOnStart}
-        padding={this.getMapPadding()}
-        hideHints={
-          this.state.isOnSmallViewport && (isNodeToolbarVisible || this.props.isMainMenuOpen)
-        }
-        {...config}
-      />
-    );
-
     const mainMenu = this.renderMainMenu({ modalNodeState, lat, lon, zoom });
     const nodeToolbar = this.renderNodeToolbar(
       { featureId, equipmentInfoId, modalNodeState, accessibilityPresetStatus },
@@ -514,7 +525,7 @@ class MainView extends React.Component<Props, State> {
             )}
             {isNodeToolbarVisible && !modalNodeState && nodeToolbar}
             {this.props.isSearchButtonVisible && this.renderSearchButton()}
-            {map}
+            {this.renderMap()}
           </div>
           {this.renderFullscreenBackdrop()}
           {isNodeToolbarVisible && modalNodeState && nodeToolbar}

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -475,37 +475,50 @@ class MainView extends React.Component<Props, State> {
       accessibilityPresetStatus,
       searchResults,
       disableWheelmapSource,
+      category,
+      className,
+      isOnboardingVisible,
+      isNotFoundVisible,
+      isMainMenuOpen,
+      isSearchBarVisible,
+      isSearchButtonVisible,
+      isNodeToolbarDisplayed: isNodeToolbarVisible,
+      lat,
+      lon,
+      zoom,
+      modalNodeState,
+      isPhotoUploadCaptchaToolbarVisible,
+      isPhotoUploadInstructionsToolbarVisible,
+      photoMarkedForReport,
+      isReportMode,
     } = this.props;
-    const category = this.props.category;
+
     const isNodeRoute = Boolean(featureId);
-    const { lat, lon, zoom, modalNodeState } = this.props;
-    const isNodeToolbarVisible = this.props.isNodeToolbarDisplayed;
 
     const classList = uniq([
       'main-view',
-      this.props.className,
-      this.props.isOnboardingVisible ? 'is-dialog-visible' : null,
-      this.props.isNotFoundVisible ? 'is-dialog-visible' : null,
-      this.props.isMainMenuOpen ? 'is-main-menu-open' : null,
-      this.props.isSearchBarVisible ? 'is-search-bar-visible' : null,
+      className,
+      isOnboardingVisible ? 'is-dialog-visible' : null,
+      isNotFoundVisible ? 'is-dialog-visible' : null,
+      isMainMenuOpen ? 'is-main-menu-open' : null,
+      isSearchBarVisible ? 'is-search-bar-visible' : null,
       isNodeToolbarVisible ? 'is-node-toolbar-visible' : null,
       modalNodeState ? 'is-dialog-visible' : null,
       modalNodeState ? 'is-modal' : null,
-      this.props.isReportMode ? 'is-report-mode' : null,
+      isReportMode ? 'is-report-mode' : null,
     ]).filter(Boolean);
 
     const searchToolbarIsHidden =
       (isNodeRoute && this.state.isOnSmallViewport) ||
-      this.props.isPhotoUploadCaptchaToolbarVisible ||
-      this.props.isPhotoUploadInstructionsToolbarVisible ||
-      this.props.isOnboardingVisible ||
-      this.props.isNotFoundVisible ||
-      !!this.props.photoMarkedForReport;
+      isPhotoUploadCaptchaToolbarVisible ||
+      isPhotoUploadInstructionsToolbarVisible ||
+      isOnboardingVisible ||
+      isNotFoundVisible ||
+      !!photoMarkedForReport;
 
-    const isMainMenuInBackground =
-      this.props.isOnboardingVisible || this.props.isNotFoundVisible || this.props.modalNodeState;
+    const isMainMenuInBackground = isOnboardingVisible || isNotFoundVisible || modalNodeState;
 
-    const searchToolbarIsInert: boolean = searchToolbarIsHidden || this.props.isMainMenuOpen;
+    const searchToolbarIsInert: boolean = searchToolbarIsHidden || isMainMenuOpen;
 
     const mainMenu = this.renderMainMenu({ modalNodeState, lat, lon, zoom });
     const nodeToolbar = this.renderNodeToolbar(
@@ -524,15 +537,14 @@ class MainView extends React.Component<Props, State> {
               searchToolbarIsInert
             )}
             {isNodeToolbarVisible && !modalNodeState && nodeToolbar}
-            {this.props.isSearchButtonVisible && this.renderSearchButton()}
+            {isSearchButtonVisible && this.renderSearchButton()}
             {this.renderMap()}
           </div>
           {this.renderFullscreenBackdrop()}
           {isNodeToolbarVisible && modalNodeState && nodeToolbar}
-          {this.props.isPhotoUploadCaptchaToolbarVisible && this.renderPhotoUploadCaptchaToolbar()}
-          {this.props.isPhotoUploadInstructionsToolbarVisible &&
-            this.renderPhotoUploadInstructionsToolbar()}
-          {this.props.photoMarkedForReport && this.renderReportPhotoToolbar()}
+          {isPhotoUploadCaptchaToolbarVisible && this.renderPhotoUploadCaptchaToolbar()}
+          {isPhotoUploadInstructionsToolbarVisible && this.renderPhotoUploadInstructionsToolbar()}
+          {photoMarkedForReport && this.renderReportPhotoToolbar()}
           {this.renderCreateDialog()}
           {this.renderOnboarding()}
         </ErrorBoundary>

--- a/src/app/PlaceDetailsData.js
+++ b/src/app/PlaceDetailsData.js
@@ -125,7 +125,7 @@ function fetchPhotos(
 }
 
 const PlaceDetailsData: DataTableEntry<PlaceDetailsProps> = {
-  async getInitialProps(query, isServer): Promise<PlaceDetailsProps> {
+  async getInitialRouteProps(query, isServer): Promise<PlaceDetailsProps> {
     const featureId = query.id;
     const equipmentInfoId = query.eid;
 

--- a/src/app/SearchData.js
+++ b/src/app/SearchData.js
@@ -63,7 +63,7 @@ async function fetchWheelmapNode(
 }
 
 const SearchData: DataTableEntry<SearchProps> = {
-  async getInitialProps(query, isServer) {
+  async getInitialRouteProps(query, isServer) {
     const searchQuery = query.q;
 
     let trimmedSearchQuery;

--- a/src/app/getInitialProps.js
+++ b/src/app/getInitialProps.js
@@ -48,7 +48,7 @@ type DataTableQuery = {
 };
 
 export type DataTableEntry<Props> = {
-  getInitialProps?: (query: DataTableQuery, isServer: boolean) => Promise<Props>,
+  getInitialRouteProps?: (query: DataTableQuery, isServer: boolean) => Promise<Props>,
   getRenderProps?: (props: Props, isServer: boolean) => Props,
   getHead?: (props: Props & AppProps) => Promise<React$Element<any>> | React$Element<any>,
   storeInitialRouteProps?: (props: Props) => void,
@@ -65,7 +65,7 @@ const dataTable: DataTable = Object.freeze({
   equipment: PlaceDetailsData,
 });
 
-export function getInitialProps(
+export function getInitialRouteProps(
   {
     routeName,
     ...query
@@ -77,11 +77,11 @@ export function getInitialProps(
 ) {
   const dataItem = dataTable[routeName];
 
-  if (!dataItem || !dataItem.getInitialProps) {
+  if (!dataItem || !dataItem.getInitialRouteProps) {
     return {};
   }
 
-  return dataItem.getInitialProps(query, isServer);
+  return dataItem.getInitialRouteProps(query, isServer);
 }
 
 export function getRenderProps<Props>(routeName: string, props: Props, isServer: boolean): Props {
@@ -94,7 +94,7 @@ export function getRenderProps<Props>(routeName: string, props: Props, isServer:
   return dataItem.getRenderProps(props, isServer);
 }
 
-export async function getAppInitialProps(
+export async function getInitialAppProps(
   {
     userAgentString,
     localeStrings,
@@ -214,7 +214,7 @@ export async function getAppInitialProps(
 
 const appPropsCache: $Shape<AppProps> = {};
 
-export function storeAppInitialProps(props: $Shape<AppProps>, isServer: boolean) {
+export function storeInitialAppProps(props: $Shape<AppProps>, isServer: boolean) {
   const {
     translations,
     rawCategoryLists,

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -27,10 +27,10 @@ import {
 } from '../lib/i18n';
 import router from '../app/router';
 import {
-  getInitialProps,
-  getAppInitialProps,
+  getInitialRouteProps,
+  getInitialAppProps,
   getRenderProps,
-  storeAppInitialProps,
+  storeInitialAppProps,
   storeInitialRouteProps,
   getHead,
   type AppProps,
@@ -49,13 +49,7 @@ let isServer = false;
 let nonSerializedProps: ?{ appProps: AppProps, routeProps: any | void } = null;
 
 export default class App extends BaseApp {
-  static async getInitialProps({
-    Component: PageComponent,
-    ctx,
-  }: {
-    Component: React.Component<>,
-    ctx: any,
-  }) {
+  static async getInitialProps({ ctx }: { ctx: any }) {
     // do not run usual routing stuff for cordova builds
     const isCordovaBuild = ctx && ctx.req && !ctx.req.headers;
     if (isCordovaBuild) {
@@ -63,7 +57,7 @@ export default class App extends BaseApp {
       const hostName = env.public.cordovaHostname;
 
       // serve only english languages
-      const initialBuildTimeProps = await getAppInitialProps(
+      const initialBuildTimeProps = await getInitialAppProps(
         { userAgentString: '', hostName, localeStrings: ['en_US'], ...ctx.query },
         true
       );
@@ -110,13 +104,13 @@ export default class App extends BaseApp {
         localeStrings = getBrowserLocaleStrings();
       }
 
-      const appPropsPromise = getAppInitialProps(
+      const appPropsPromise = getInitialAppProps(
         { userAgentString, hostName, localeStrings, ...ctx.query },
         isServer
       );
 
       if (ctx.query.routeName) {
-        const routePropsPromise = getInitialProps(ctx.query, isServer);
+        const routePropsPromise = getInitialRouteProps(ctx.query, isServer);
         routeProps = await routePropsPromise;
       }
       appProps = await appPropsPromise;
@@ -246,7 +240,7 @@ export default class App extends BaseApp {
     }
 
     // store app initial props (use this.props to cache rawCategoryLists)
-    storeAppInitialProps(this.props, isServer);
+    storeInitialAppProps(this.props, isServer);
     if (routeName) {
       storeInitialRouteProps(routeName, appProps);
     }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -104,16 +104,14 @@ export default class App extends BaseApp {
         localeStrings = getBrowserLocaleStrings();
       }
 
-      const appPropsPromise = getInitialAppProps(
+      if (ctx.query.routeName) {
+        routeProps = await getInitialRouteProps(ctx.query, isServer);
+      }
+
+      appProps = await getInitialAppProps(
         { userAgentString, hostName, localeStrings, ...ctx.query },
         isServer
       );
-
-      if (ctx.query.routeName) {
-        const routePropsPromise = getInitialRouteProps(ctx.query, isServer);
-        routeProps = await routePropsPromise;
-      }
-      appProps = await appPropsPromise;
 
       if (isServer) {
         ctx.res.set({ Vary: 'X-User-Agent-Variant, X-Locale-Variant' });

--- a/src/pages/cordova.js
+++ b/src/pages/cordova.js
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 
 import savedState, { saveState } from '../lib/savedState';
 import env from '../lib/env';
-import { getAppInitialProps, storeAppInitialProps, type AppProps } from '../app/getInitialProps';
+import { getInitialAppProps, storeInitialAppProps, type AppProps } from '../app/getInitialProps';
 import {
   addTranslationsToTTag,
   getAvailableTranslationsByPreference,
@@ -73,19 +73,19 @@ class CordovaMain extends React.PureComponent<Props, State> {
         overrideLocaleString
       );
       addTranslationsToTTag(translations);
-      storeAppInitialProps({ translations }, isBuilding);
+      storeInitialAppProps({ translations }, isBuilding);
     }
 
     // inject the build time data into the initial props, these are only available on the initial route
     if (props.buildTimeProps) {
       const { translations, ...remainingBuildTimeProps } = props.buildTimeProps;
       this.state.buildTimeProps = remainingBuildTimeProps;
-      storeAppInitialProps(remainingBuildTimeProps, isBuilding);
+      storeInitialAppProps(remainingBuildTimeProps, isBuilding);
     }
 
     // if we have stored props, use these to override the build time props
     if (savedState.initialProps) {
-      storeAppInitialProps(savedState.initialProps, isBuilding);
+      storeInitialAppProps(savedState.initialProps, isBuilding);
     }
   }
 
@@ -117,7 +117,7 @@ class CordovaMain extends React.PureComponent<Props, State> {
     if (isCordovaDebugMode()) {
       queryProps.disableWheelmapSource = 'true';
     }
-    const expectedPromise = getAppInitialProps(queryProps, false, false);
+    const expectedPromise = getInitialAppProps(queryProps, false, false);
 
     this.setState({ expectedPromise }, () => {
       expectedPromise
@@ -139,7 +139,7 @@ class CordovaMain extends React.PureComponent<Props, State> {
     // strip translations, no need to cache them
     const { rawCategoryLists, clientSideConfiguration } = reloadedInitialProps;
 
-    storeAppInitialProps({ rawCategoryLists, clientSideConfiguration }, isBuilding);
+    storeInitialAppProps({ rawCategoryLists, clientSideConfiguration }, isBuilding);
     this.setState({
       storedInitialProps: { rawCategoryLists, clientSideConfiguration },
     });

--- a/src/pages/main.js
+++ b/src/pages/main.js
@@ -1,30 +1,3 @@
 // @flow
 
-// import Link from 'next/link';
-
-import * as React from 'react';
-// import ReactDOM from 'react-dom';
-// import axe from 'react-axe';
-import App from '../App';
-
-// import registerServiceWorker from './registerServiceWorker';
-
-// const a11yAuditActive = false;
-
-// if (process.env.NODE_ENV === 'development' && a11yAuditActive) {
-//   axe(React, ReactDOM, 1000);
-// }
-
-// Don't let the body scroll.
-// document.body.addEventListener('touchmove', e => e.preventDefault(), false);
-// document.addEventListener('touchmove', e => e.preventDefault(), false);
-
-// registerServiceWorker();
-
-export default function Main(props) {
-  return (
-    <React.Fragment>
-      <App {...props} />
-    </React.Fragment>
-  );
-}
+export { default } from '../App';


### PR DESCRIPTION
Improvements:

* Our own `getInitialProps` now is called `getInitialRouteProps`
* `getAppInitialProps` is now called `getInitialAppProps` to be more consistent with `getInitialRouteProps`
* Same for the `store...` methods
* Condensed the whole main.js file to one line (a lot of dead code removed)
* Some small "await" conciseness
* Cleanup of the `MainView#render` method by moving `this.props...` statements
* Cleanup of `MainView` subrender methods
* Removal of some dead code