### PR TITLE
Wheelmap Embed Mode

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -170,9 +170,13 @@ class App extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    const { routeName, inEmbedMode } = this.props;
+
+    const shouldStartInSearch = routeName === 'map' && !inEmbedMode;
+
     if (isFirstStart()) {
       this.setState({ isOnboardingVisible: true });
-    } else if (this.props.routeName === 'map' && !this.props.inEmbedMode) {
+    } else if (shouldStartInSearch) {
       this.openSearch(true);
     }
   }

--- a/src/App.js
+++ b/src/App.js
@@ -64,6 +64,7 @@ type Props = {
   lon: ?string,
   zoom: ?string,
   extent: ?[number, number, number, number],
+  isEmbeddedWidget: boolean,
 
   includeSourceIds: Array<string>,
   excludeSourceIds: Array<string>,
@@ -640,6 +641,7 @@ class App extends React.Component<Props, State> {
       isOnSmallViewport: this.state.isOnSmallViewport,
       isSearchToolbarExpanded: this.state.isSearchToolbarExpanded,
       searchResults: this.props.searchResults,
+      isEmbeddedWidget: this.props.isEmbeddedWidget,
 
       disableWheelmapSource: this.props.disableWheelmapSource,
       includeSourceIds: this.props.includeSourceIds,

--- a/src/App.js
+++ b/src/App.js
@@ -172,7 +172,7 @@ class App extends React.Component<Props, State> {
   componentDidMount() {
     if (isFirstStart()) {
       this.setState({ isOnboardingVisible: true });
-    } else if (this.props.routeName === 'map') {
+    } else if (this.props.routeName === 'map' && !this.props.inEmbedMode) {
       this.openSearch(true);
     }
   }

--- a/src/App.js
+++ b/src/App.js
@@ -434,6 +434,7 @@ class App extends React.Component<Props, State> {
       excludeSourceIds,
       clientSideConfiguration,
       overriddenAppId,
+      isEmbeddedWidget,
     } = this.props;
 
     if (category) {
@@ -480,6 +481,10 @@ class App extends React.Component<Props, State> {
 
     if (overriddenAppId) {
       params.appId = overriddenAppId;
+    }
+
+    if (isEmbeddedWidget) {
+      params.embedded = 'true';
     }
 
     return params;

--- a/src/App.js
+++ b/src/App.js
@@ -64,7 +64,7 @@ type Props = {
   lon: ?string,
   zoom: ?string,
   extent: ?[number, number, number, number],
-  isEmbeddedWidget: boolean,
+  inEmbedMode: boolean,
 
   includeSourceIds: Array<string>,
   excludeSourceIds: Array<string>,
@@ -434,7 +434,7 @@ class App extends React.Component<Props, State> {
       excludeSourceIds,
       clientSideConfiguration,
       overriddenAppId,
-      isEmbeddedWidget,
+      inEmbedMode,
     } = this.props;
 
     if (category) {
@@ -483,7 +483,7 @@ class App extends React.Component<Props, State> {
       params.appId = overriddenAppId;
     }
 
-    if (isEmbeddedWidget) {
+    if (inEmbedMode) {
       params.embedded = 'true';
     }
 
@@ -646,7 +646,7 @@ class App extends React.Component<Props, State> {
       isOnSmallViewport: this.state.isOnSmallViewport,
       isSearchToolbarExpanded: this.state.isSearchToolbarExpanded,
       searchResults: this.props.searchResults,
-      isEmbeddedWidget: this.props.isEmbeddedWidget,
+      inEmbedMode: this.props.inEmbedMode,
 
       disableWheelmapSource: this.props.disableWheelmapSource,
       includeSourceIds: this.props.includeSourceIds,

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -520,13 +520,13 @@ class MainView extends React.Component<Props, State> {
         {!inEmbedMode && !isMainMenuInBackground && this.renderMainMenu()}
         <ErrorBoundary>
           <div className="behind-backdrop">
+            {inEmbedMode && (
+              <PositionedWheelmapHomeLink logoURL={clientSideConfiguration.logoURL} />
+            )}
             {!inEmbedMode && isMainMenuInBackground && this.renderMainMenu()}
             {!inEmbedMode && this.renderSearchToolbar(searchToolbarIsInert)}
             {isNodeToolbarVisible && !modalNodeState && this.renderNodeToolbar(isNodeRoute)}
             {!inEmbedMode && isSearchButtonVisible && this.renderSearchButton()}
-            {inEmbedMode && (
-              <PositionedWheelmapHomeLink logoURL={clientSideConfiguration.logoURL} />
-            )}
             {this.renderMap()}
           </div>
           {this.renderFullscreenBackdrop()}
@@ -611,9 +611,14 @@ const StyledMainView = styled(MainView)`
 
 const PositionedWheelmapHomeLink = styled(WheelmapHomeLink)`
   position: absolute;
-  margin-top: 10px;
-  margin-left: 10px;
+  top: 10px;
+  right: 70px;
   z-index: 1001;
+
+  @media (max-width: 512px) {
+    right: initial;
+    left: 10px;
+  }
 `;
 
 export default StyledMainView;

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -392,6 +392,7 @@ class MainView extends React.Component<Props, State> {
         waitingForPhotoUpload={this.props.waitingForPhotoUpload}
         onClose={this.props.onAbortPhotoUploadFlow}
         onCompleted={this.props.onContinuePhotoUploadFlow}
+        isEmbeddedWidget={this.props.isEmbeddedWidget}
       />
     );
   }

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import styled from 'styled-components';
 import includes from 'lodash/includes';
 import uniq from 'lodash/uniq';
+import queryString from 'query-string';
 
 import MainMenu from './components/MainMenu/MainMenu';
 import NodeToolbarFeatureLoader from './components/NodeToolbar/NodeToolbarFeatureLoader';
@@ -21,6 +22,7 @@ import WheelmapHomeLink from './components/WheelmapHomeLink';
 import type { SearchResultFeature } from './lib/searchPlaces';
 import type { WheelmapFeature } from './lib/Feature';
 import type { EquipmentInfo } from './lib/EquipmentInfo';
+import { translatedStringFromObject } from './lib/i18n';
 
 import SearchButton from './components/SearchToolbar/SearchButton';
 import Onboarding from './components/Onboarding/Onboarding';
@@ -468,6 +470,24 @@ class MainView extends React.Component<Props, State> {
     );
   }
 
+  renderWheelmapHomeLink() {
+    if (typeof window !== 'undefined') {
+      const { clientSideConfiguration } = this.props;
+      const appName = translatedStringFromObject(clientSideConfiguration.textContent.product.name);
+      const logoURL = clientSideConfiguration.logoURL;
+
+      const queryParams = queryString.parse(window.location.search);
+      delete queryParams.embedded;
+      const queryStringWithoutEmbeddedParam = queryString.stringify(queryParams);
+
+      const homeLinkHref = `${window.location.origin}${
+        window.location.pathname
+      }?${queryStringWithoutEmbeddedParam}`;
+
+      return <PositionedWheelmapHomeLink href={homeLinkHref} appName={appName} logoURL={logoURL} />;
+    }
+  }
+
   render() {
     const {
       featureId,
@@ -484,7 +504,6 @@ class MainView extends React.Component<Props, State> {
       photoMarkedForReport,
       isReportMode,
       inEmbedMode,
-      clientSideConfiguration,
     } = this.props;
 
     const isNodeRoute = Boolean(featureId);
@@ -520,9 +539,7 @@ class MainView extends React.Component<Props, State> {
         {!inEmbedMode && !isMainMenuInBackground && this.renderMainMenu()}
         <ErrorBoundary>
           <div className="behind-backdrop">
-            {inEmbedMode && (
-              <PositionedWheelmapHomeLink logoURL={clientSideConfiguration.logoURL} />
-            )}
+            {inEmbedMode && this.renderWheelmapHomeLink()}
             {!inEmbedMode && isMainMenuInBackground && this.renderMainMenu()}
             {!inEmbedMode && this.renderSearchToolbar(searchToolbarIsInert)}
             {isNodeToolbarVisible && !modalNodeState && this.renderNodeToolbar(isNodeRoute)}

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -245,6 +245,7 @@ class MainView extends React.Component<Props, State> {
           onReportPhoto={this.props.onStartReportPhotoFlow}
           onEquipmentSelected={this.props.onEquipmentSelected}
           onShowPlaceDetails={this.props.onShowPlaceDetails}
+          isEmbeddedWidget={this.props.isEmbeddedWidget}
         />
       </div>
     );

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -17,6 +17,7 @@ import PhotoUploadCaptchaToolbar from './components/PhotoUpload/PhotoUploadCaptc
 import PhotoUploadInstructionsToolbar from './components/PhotoUpload/PhotoUploadInstructionsToolbar';
 import MapLoading from './components/Map/MapLoading';
 import ErrorBoundary from './components/ErrorBoundary';
+import WheelmapHomeLink from './components/WheelmapHomeLink';
 import type { SearchResultFeature } from './lib/searchPlaces';
 import type { WheelmapFeature } from './lib/Feature';
 import type { EquipmentInfo } from './lib/EquipmentInfo';
@@ -483,6 +484,7 @@ class MainView extends React.Component<Props, State> {
       photoMarkedForReport,
       isReportMode,
       isEmbeddedWidget,
+      clientSideConfiguration,
     } = this.props;
 
     const isNodeRoute = Boolean(featureId);
@@ -522,6 +524,9 @@ class MainView extends React.Component<Props, State> {
             {!isEmbeddedWidget && this.renderSearchToolbar(searchToolbarIsInert)}
             {isNodeToolbarVisible && !modalNodeState && this.renderNodeToolbar(isNodeRoute)}
             {!isEmbeddedWidget && isSearchButtonVisible && this.renderSearchButton()}
+            {isEmbeddedWidget && (
+              <PositionedWheelmapHomeLink logoURL={clientSideConfiguration.logoURL} />
+            )}
             {this.renderMap()}
           </div>
           {this.renderFullscreenBackdrop()}
@@ -602,6 +607,13 @@ const StyledMainView = styled(MainView)`
       z-index: 1001;
     }
   }
+`;
+
+const PositionedWheelmapHomeLink = styled(WheelmapHomeLink)`
+  position: absolute;
+  margin-top: 10px;
+  margin-left: 10px;
+  z-index: 1001;
 `;
 
 export default StyledMainView;

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -60,7 +60,7 @@ type Props = {
   lon: ?number,
   zoom: ?number,
   extent: ?[number, number, number, number],
-  isEmbeddedWidget: boolean,
+  inEmbedMode: boolean,
 
   includeSourceIds: Array<string>,
   excludeSourceIds: Array<string>,
@@ -246,7 +246,7 @@ class MainView extends React.Component<Props, State> {
           onReportPhoto={this.props.onStartReportPhotoFlow}
           onEquipmentSelected={this.props.onEquipmentSelected}
           onShowPlaceDetails={this.props.onShowPlaceDetails}
-          isEmbeddedWidget={this.props.isEmbeddedWidget}
+          inEmbedMode={this.props.inEmbedMode}
         />
       </div>
     );
@@ -393,7 +393,7 @@ class MainView extends React.Component<Props, State> {
         waitingForPhotoUpload={this.props.waitingForPhotoUpload}
         onClose={this.props.onAbortPhotoUploadFlow}
         onCompleted={this.props.onContinuePhotoUploadFlow}
-        isEmbeddedWidget={this.props.isEmbeddedWidget}
+        inEmbedMode={this.props.inEmbedMode}
       />
     );
   }
@@ -483,7 +483,7 @@ class MainView extends React.Component<Props, State> {
       isPhotoUploadInstructionsToolbarVisible,
       photoMarkedForReport,
       isReportMode,
-      isEmbeddedWidget,
+      inEmbedMode,
       clientSideConfiguration,
     } = this.props;
 
@@ -500,7 +500,7 @@ class MainView extends React.Component<Props, State> {
       modalNodeState ? 'is-dialog-visible' : null,
       modalNodeState ? 'is-modal' : null,
       isReportMode ? 'is-report-mode' : null,
-      isEmbeddedWidget ? 'is-embedded-widget' : null,
+      inEmbedMode ? 'in-embed-mode' : null,
     ]).filter(Boolean);
 
     const searchToolbarIsHidden =
@@ -517,14 +517,14 @@ class MainView extends React.Component<Props, State> {
 
     return (
       <div className={classList.join(' ')}>
-        {!isEmbeddedWidget && !isMainMenuInBackground && this.renderMainMenu()}
+        {!inEmbedMode && !isMainMenuInBackground && this.renderMainMenu()}
         <ErrorBoundary>
           <div className="behind-backdrop">
-            {!isEmbeddedWidget && isMainMenuInBackground && this.renderMainMenu()}
-            {!isEmbeddedWidget && this.renderSearchToolbar(searchToolbarIsInert)}
+            {!inEmbedMode && isMainMenuInBackground && this.renderMainMenu()}
+            {!inEmbedMode && this.renderSearchToolbar(searchToolbarIsInert)}
             {isNodeToolbarVisible && !modalNodeState && this.renderNodeToolbar(isNodeRoute)}
-            {!isEmbeddedWidget && isSearchButtonVisible && this.renderSearchButton()}
-            {isEmbeddedWidget && (
+            {!inEmbedMode && isSearchButtonVisible && this.renderSearchButton()}
+            {inEmbedMode && (
               <PositionedWheelmapHomeLink logoURL={clientSideConfiguration.logoURL} />
             )}
             {this.renderMap()}

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -59,6 +59,7 @@ type Props = {
   lon: ?number,
   zoom: ?number,
   extent: ?[number, number, number, number],
+  isEmbeddedWidget: boolean,
 
   includeSourceIds: Array<string>,
   excludeSourceIds: Array<string>,
@@ -479,6 +480,7 @@ class MainView extends React.Component<Props, State> {
       isPhotoUploadInstructionsToolbarVisible,
       photoMarkedForReport,
       isReportMode,
+      isEmbeddedWidget,
     } = this.props;
 
     const isNodeRoute = Boolean(featureId);
@@ -507,6 +509,23 @@ class MainView extends React.Component<Props, State> {
     const isMainMenuInBackground = isOnboardingVisible || isNotFoundVisible || modalNodeState;
 
     const searchToolbarIsInert: boolean = searchToolbarIsHidden || isMainMenuOpen;
+
+    if (isEmbeddedWidget) {
+      return (
+        <div className={classList.join(' ')}>
+          <ErrorBoundary>
+            {this.renderMap()}
+            {isNodeToolbarVisible && modalNodeState && this.renderNodeToolbar(isNodeRoute)}
+            {this.props.isPhotoUploadCaptchaToolbarVisible &&
+              this.renderPhotoUploadCaptchaToolbar()}
+            {this.props.isPhotoUploadInstructionsToolbarVisible &&
+              this.renderPhotoUploadInstructionsToolbar()}
+            {this.props.photoMarkedForReport && this.renderReportPhotoToolbar()}
+            {this.renderCreateDialog()}
+          </ErrorBoundary>
+        </div>
+      );
+    }
 
     return (
       <div className={classList.join(' ')}>

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -510,32 +510,15 @@ class MainView extends React.Component<Props, State> {
 
     const searchToolbarIsInert: boolean = searchToolbarIsHidden || isMainMenuOpen;
 
-    if (isEmbeddedWidget) {
-      return (
-        <div className={classList.join(' ')}>
-          <ErrorBoundary>
-            {this.renderMap()}
-            {isNodeToolbarVisible && modalNodeState && this.renderNodeToolbar(isNodeRoute)}
-            {this.props.isPhotoUploadCaptchaToolbarVisible &&
-              this.renderPhotoUploadCaptchaToolbar()}
-            {this.props.isPhotoUploadInstructionsToolbarVisible &&
-              this.renderPhotoUploadInstructionsToolbar()}
-            {this.props.photoMarkedForReport && this.renderReportPhotoToolbar()}
-            {this.renderCreateDialog()}
-          </ErrorBoundary>
-        </div>
-      );
-    }
-
     return (
       <div className={classList.join(' ')}>
-        {!isMainMenuInBackground && this.renderMainMenu()}
+        {!isEmbeddedWidget && !isMainMenuInBackground && this.renderMainMenu()}
         <ErrorBoundary>
           <div className="behind-backdrop">
-            {isMainMenuInBackground && this.renderMainMenu()}
-            {this.renderSearchToolbar(searchToolbarIsInert)}
+            {!isEmbeddedWidget && isMainMenuInBackground && this.renderMainMenu()}
+            {!isEmbeddedWidget && this.renderSearchToolbar(searchToolbarIsInert)}
             {isNodeToolbarVisible && !modalNodeState && this.renderNodeToolbar(isNodeRoute)}
-            {isSearchButtonVisible && this.renderSearchButton()}
+            {!isEmbeddedWidget && isSearchButtonVisible && this.renderSearchButton()}
             {this.renderMap()}
           </div>
           {this.renderFullscreenBackdrop()}

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -496,6 +496,7 @@ class MainView extends React.Component<Props, State> {
       modalNodeState ? 'is-dialog-visible' : null,
       modalNodeState ? 'is-modal' : null,
       isReportMode ? 'is-report-mode' : null,
+      isEmbeddedWidget ? 'is-embedded-widget' : null,
     ]).filter(Boolean);
 
     const searchToolbarIsHidden =

--- a/src/app/getInitialProps.js
+++ b/src/app/getInitialProps.js
@@ -111,7 +111,7 @@ export async function getInitialAppProps(
     excludeSourceIds,
     disableWheelmapSource: overriddenWheelmapSource,
     appId: overriddenAppId,
-
+    embedded,
     ...query
   }: {
     userAgentString: string,
@@ -128,6 +128,7 @@ export async function getInitialAppProps(
     excludeSourceIds?: string,
     disableWheelmapSource?: string,
     appId?: string,
+    embedded?: string,
     [key: string]: ?string,
   },
   isServer: boolean,
@@ -208,6 +209,7 @@ export async function getInitialAppProps(
     includeSourceIds: includeSourceIdsArray,
     excludeSourceIds: excludeSourceIdsArray,
     disableWheelmapSource: usedDisableWheelmapSource,
+    isEmbeddedWidget: embedded === 'true',
   };
   return appProps;
 }

--- a/src/app/getInitialProps.js
+++ b/src/app/getInitialProps.js
@@ -209,7 +209,7 @@ export async function getInitialAppProps(
     includeSourceIds: includeSourceIdsArray,
     excludeSourceIds: excludeSourceIdsArray,
     disableWheelmapSource: usedDisableWheelmapSource,
-    isEmbeddedWidget: embedded === 'true',
+    inEmbedMode: embedded === 'true',
   };
   return appProps;
 }

--- a/src/components/Map/Map.css
+++ b/src/components/Map/Map.css
@@ -10,7 +10,7 @@ body.is-touch-device .leaflet-control-zoom {
     margin-top: 50px;
   }
 
-  .is-embedded-widget .leaflet-control-container .leaflet-top {
+  .in-embed-mode .leaflet-control-container .leaflet-top {
     margin-top: 0;
   }
 
@@ -30,7 +30,7 @@ body.is-touch-device .leaflet-control-zoom {
     sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
-.is-embedded-widget .leaflet-container {
+.in-embed-mode .leaflet-container {
   height: 100vh;
 }
 

--- a/src/components/Map/Map.css
+++ b/src/components/Map/Map.css
@@ -30,6 +30,10 @@ body.is-touch-device .leaflet-control-zoom {
     sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
+.is-embedded-widget .leaflet-container {
+  height: 100vh;
+}
+
 @media (max-width: 1024px) {
   .leaflet-container {
     height: 100vh;

--- a/src/components/Map/Map.css
+++ b/src/components/Map/Map.css
@@ -9,6 +9,11 @@ body.is-touch-device .leaflet-control-zoom {
     top: env(safe-area-inset-top);
     margin-top: 50px;
   }
+
+  .is-embedded-widget .leaflet-control-container .leaflet-top {
+    margin-top: 0;
+  }
+
   .leaflet-control-container .leaflet-right {
     right: 0px;
     right: constant(safe-area-inset-right);

--- a/src/components/NodeToolbar/IconButtonList/PlaceWebsiteLink.js
+++ b/src/components/NodeToolbar/IconButtonList/PlaceWebsiteLink.js
@@ -31,7 +31,12 @@ export default function PlaceWebsiteLink(props: Props) {
 
   return (
     typeof placeWebsiteUrl === 'string' && (
-      <NonBreakingLink className="link-button" href={placeWebsiteUrl}>
+      <NonBreakingLink
+        className="link-button"
+        href={placeWebsiteUrl}
+        target="_blank"
+        rel="noreferrer noopener"
+      >
         <WorldIcon />
         <span>{placeWebsiteUrl}</span>
       </NonBreakingLink>

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -57,6 +57,7 @@ type Props = {
   parentCategory: ?Category,
   hidden: boolean,
   modalNodeState: ModalNodeState,
+  isEmbeddedWidget: boolean,
   onClose: () => void,
   onOpenReportMode: ?() => void,
   onOpenToiletAccessibility: () => void,
@@ -349,6 +350,7 @@ class NodeToolbar extends React.Component<Props, State> {
         ariaLabel={this.placeName()}
         startTopOffset={offset}
         onScrollable={isScrollable => this.setState({ isScrollable })}
+        isEmbeddedWidget={this.props.isEmbeddedWidget}
       >
         <ErrorBoundary>
           <FocusTrap

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -57,7 +57,7 @@ type Props = {
   parentCategory: ?Category,
   hidden: boolean,
   modalNodeState: ModalNodeState,
-  isEmbeddedWidget: boolean,
+  inEmbedMode: boolean,
   onClose: () => void,
   onOpenReportMode: ?() => void,
   onOpenToiletAccessibility: () => void,
@@ -350,7 +350,7 @@ class NodeToolbar extends React.Component<Props, State> {
         ariaLabel={this.placeName()}
         startTopOffset={offset}
         onScrollable={isScrollable => this.setState({ isScrollable })}
-        isEmbeddedWidget={this.props.isEmbeddedWidget}
+        inEmbedMode={this.props.inEmbedMode}
       >
         <ErrorBoundary>
           <FocusTrap

--- a/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
+++ b/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
@@ -29,7 +29,7 @@ type Props = {
   onShowPlaceDetails: (featureId: string | number) => void,
   hidden: boolean,
   modalNodeState: ModalNodeState,
-  isEmbeddedWidget: boolean,
+  inEmbedMode: boolean,
   onClose: () => void,
   onOpenReportMode: ?() => void,
   onOpenToiletAccessibility: () => void,

--- a/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
+++ b/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
@@ -29,6 +29,7 @@ type Props = {
   onShowPlaceDetails: (featureId: string | number) => void,
   hidden: boolean,
   modalNodeState: ModalNodeState,
+  isEmbeddedWidget: boolean,
   onClose: () => void,
   onOpenReportMode: ?() => void,
   onOpenToiletAccessibility: () => void,

--- a/src/components/NodeToolbar/StyledToolbar.js
+++ b/src/components/NodeToolbar/StyledToolbar.js
@@ -20,9 +20,13 @@ const StyledToolbar = styled(Toolbar)`
     top: calc(${props => (props.inEmbedMode ? 0 : 50)}px + env(safe-area-inset-top));
 
     @media (orientation: landscape) {
-      max-height: calc(100% - 80px);
-      max-height: calc(100% - 80px - constant(safe-area-inset-top));
-      max-height: calc(100% - 80px - env(safe-area-inset-top));
+      max-height: calc(100% - ${props => (props.inEmbedMode ? 0 : 80)}px);
+      max-height: calc(
+        100% - ${props => (props.inEmbedMode ? 0 : 80)}px - constant(safe-area-inset-top)
+      );
+      max-height: calc(
+        100% - ${props => (props.inEmbedMode ? 0 : 80)}px - env(safe-area-inset-top)
+      );
     }
   }
 `;

--- a/src/components/NodeToolbar/StyledToolbar.js
+++ b/src/components/NodeToolbar/StyledToolbar.js
@@ -4,9 +4,9 @@ import Toolbar from '../Toolbar';
 const StyledToolbar = styled(Toolbar)`
   hyphens: auto;
 
-  top: 110px;
-  top: calc(110px + constant(safe-area-inset-top));
-  top: calc(110px + env(safe-area-inset-top));
+  top: ${props => (props.isEmbeddedWidget ? 0 : 110)}px;
+  top: calc(${props => (props.isEmbeddedWidget ? 0 : 110)}px + constant(safe-area-inset-top));
+  top: calc(${props => (props.isEmbeddedWidget ? 0 : 110)}px + env(safe-area-inset-top));
   max-height: calc(100% - 120px);
   max-height: calc(100% - 120px - constant(safe-area-inset-top));
   max-height: calc(100% - 120px - env(safe-area-inset-top));

--- a/src/components/NodeToolbar/StyledToolbar.js
+++ b/src/components/NodeToolbar/StyledToolbar.js
@@ -7,15 +7,19 @@ const StyledToolbar = styled(Toolbar)`
   top: ${props => (props.isEmbeddedWidget ? 0 : 110)}px;
   top: calc(${props => (props.isEmbeddedWidget ? 0 : 110)}px + constant(safe-area-inset-top));
   top: calc(${props => (props.isEmbeddedWidget ? 0 : 110)}px + env(safe-area-inset-top));
-  max-height: calc(100% - 120px);
-  max-height: calc(100% - 120px - constant(safe-area-inset-top));
-  max-height: calc(100% - 120px - env(safe-area-inset-top));
+  max-height: calc(100% - ${props => (props.isEmbeddedWidget ? 70 : 120)}px);
+  max-height: calc(
+    100% - ${props => (props.isEmbeddedWidget ? 70 : 120)}px - constant(safe-area-inset-top)
+  );
+  max-height: calc(
+    100% - ${props => (props.isEmbeddedWidget ? 70 : 120)}px - env(safe-area-inset-top)
+  );
   padding-top: 0;
 
   @media (max-width: 512px), (max-height: 512px) {
-    top: 50px;
-    top: calc(50px + constant(safe-area-inset-top));
-    top: calc(50px + env(safe-area-inset-top));
+    top: ${props => (props.isEmbeddedWidget ? 0 : 50)}px;
+    top: calc(${props => (props.isEmbeddedWidget ? 0 : 50)}px + constant(safe-area-inset-top));
+    top: calc(${props => (props.isEmbeddedWidget ? 0 : 50)}px + env(safe-area-inset-top));
 
     @media (orientation: landscape) {
       max-height: calc(100% - 80px);

--- a/src/components/NodeToolbar/StyledToolbar.js
+++ b/src/components/NodeToolbar/StyledToolbar.js
@@ -4,22 +4,20 @@ import Toolbar from '../Toolbar';
 const StyledToolbar = styled(Toolbar)`
   hyphens: auto;
 
-  top: ${props => (props.isEmbeddedWidget ? 0 : 110)}px;
-  top: calc(${props => (props.isEmbeddedWidget ? 0 : 110)}px + constant(safe-area-inset-top));
-  top: calc(${props => (props.isEmbeddedWidget ? 0 : 110)}px + env(safe-area-inset-top));
-  max-height: calc(100% - ${props => (props.isEmbeddedWidget ? 70 : 120)}px);
+  top: ${props => (props.inEmbedMode ? 0 : 110)}px;
+  top: calc(${props => (props.inEmbedMode ? 0 : 110)}px + constant(safe-area-inset-top));
+  top: calc(${props => (props.inEmbedMode ? 0 : 110)}px + env(safe-area-inset-top));
+  max-height: calc(100% - ${props => (props.inEmbedMode ? 70 : 120)}px);
   max-height: calc(
-    100% - ${props => (props.isEmbeddedWidget ? 70 : 120)}px - constant(safe-area-inset-top)
+    100% - ${props => (props.inEmbedMode ? 70 : 120)}px - constant(safe-area-inset-top)
   );
-  max-height: calc(
-    100% - ${props => (props.isEmbeddedWidget ? 70 : 120)}px - env(safe-area-inset-top)
-  );
+  max-height: calc(100% - ${props => (props.inEmbedMode ? 70 : 120)}px - env(safe-area-inset-top));
   padding-top: 0;
 
   @media (max-width: 512px), (max-height: 512px) {
-    top: ${props => (props.isEmbeddedWidget ? 0 : 50)}px;
-    top: calc(${props => (props.isEmbeddedWidget ? 0 : 50)}px + constant(safe-area-inset-top));
-    top: calc(${props => (props.isEmbeddedWidget ? 0 : 50)}px + env(safe-area-inset-top));
+    top: ${props => (props.inEmbedMode ? 0 : 50)}px;
+    top: calc(${props => (props.inEmbedMode ? 0 : 50)}px + constant(safe-area-inset-top));
+    top: calc(${props => (props.inEmbedMode ? 0 : 50)}px + env(safe-area-inset-top));
 
     @media (orientation: landscape) {
       max-height: calc(100% - 80px);

--- a/src/components/PhotoUpload/PhotoUploadInstructionsToolbar.js
+++ b/src/components/PhotoUpload/PhotoUploadInstructionsToolbar.js
@@ -14,7 +14,7 @@ import colors from '../../lib/colors';
 export type Props = {
   hidden: boolean,
   waitingForPhotoUpload?: boolean,
-  isEmbeddedWidget: boolean,
+  inEmbedMode: boolean,
   onClose: ?() => void,
   onCompleted: ?(photos: FileList) => void,
 };
@@ -296,7 +296,7 @@ export default class PhotoUploadInstructionsToolbar extends React.Component<Prop
         hidden={this.props.hidden}
         isSwipeable={false}
         isModal
-        isEmbeddedWidget={this.props.isEmbeddedWidget}
+        inEmbedMode={this.props.inEmbedMode}
       >
         <header>
           {this.renderCloseLink()}

--- a/src/components/PhotoUpload/PhotoUploadInstructionsToolbar.js
+++ b/src/components/PhotoUpload/PhotoUploadInstructionsToolbar.js
@@ -14,6 +14,7 @@ import colors from '../../lib/colors';
 export type Props = {
   hidden: boolean,
   waitingForPhotoUpload?: boolean,
+  isEmbeddedWidget: boolean,
   onClose: ?() => void,
   onCompleted: ?(photos: FileList) => void,
 };
@@ -125,7 +126,7 @@ const StyledToolbar = styled(Toolbar)`
             .entrance-image { background-image: url('/static/images/photo-upload/entrancePlaceholder.png'); }
             .sitemap-image { background-image: url('/static/images/photo-upload/sitemapPlaceholder.png'); }
             .toilet-image { background-image: url('/static/images/photo-upload/toiletPlaceholder.png'); }
-            
+
             small {
               font-size: 0.8rem;
               padding-left: 0;
@@ -295,6 +296,7 @@ export default class PhotoUploadInstructionsToolbar extends React.Component<Prop
         hidden={this.props.hidden}
         isSwipeable={false}
         isModal
+        isEmbeddedWidget={this.props.isEmbeddedWidget}
       >
         <header>
           {this.renderCloseLink()}

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -374,9 +374,13 @@ const StyledToolbar = styled(Toolbar)`
       top: 0px;
       top: constant(safe-area-inset-top);
       top: env(safe-area-inset-top);
-      max-height: calc(100% - 120px);
-      max-height: calc(100% - 120px - constant(safe-area-inset-top));
-      max-height: calc(100% - 120px - env(safe-area-inset-top));
+      max-height: calc(100% - ${props => (props.isEmbeddedWidget ? 60 : 120)}px);
+      max-height: calc(
+        100% - ${props => (props.isEmbeddedWidget ? 60 : 120)}px - constant(safe-area-inset-top)
+      );
+      max-height: calc(
+        100% - ${props => (props.isEmbeddedWidget ? 60 : 120)}px - env(safe-area-inset-top)
+      );
       margin-top: 0;
     }
   }

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -374,12 +374,12 @@ const StyledToolbar = styled(Toolbar)`
       top: 0px;
       top: constant(safe-area-inset-top);
       top: env(safe-area-inset-top);
-      max-height: calc(100% - ${props => (props.isEmbeddedWidget ? 60 : 120)}px);
+      max-height: calc(100% - ${props => (props.inEmbedMode ? 60 : 120)}px);
       max-height: calc(
-        100% - ${props => (props.isEmbeddedWidget ? 60 : 120)}px - constant(safe-area-inset-top)
+        100% - ${props => (props.inEmbedMode ? 60 : 120)}px - constant(safe-area-inset-top)
       );
       max-height: calc(
-        100% - ${props => (props.isEmbeddedWidget ? 60 : 120)}px - env(safe-area-inset-top)
+        100% - ${props => (props.inEmbedMode ? 60 : 120)}px - env(safe-area-inset-top)
       );
       margin-top: 0;
     }

--- a/src/components/WheelmapHomeLink.js
+++ b/src/components/WheelmapHomeLink.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { t } from 'ttag';
 import styled from 'styled-components';
 
-const WheelmapHomeLink = ({ className, logoURL }) => (
+const WheelmapHomeLink = ({ className, logoURL, href, appName }) => (
   <a
     className={className}
-    href="https://wheelmap.org"
-    aria-label={t`Go to wheelmap.org`}
+    href={href}
+    // translator: The link name to go from the embedded to the complete app
+    aria-label={t`Go to ${appName}`}
     target="_blank"
     rel="noreferrer noopener"
   >

--- a/src/components/WheelmapHomeLink.js
+++ b/src/components/WheelmapHomeLink.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { t } from 'ttag';
+import styled from 'styled-components';
+
+const WheelmapHomeLink = ({ className, logoURL }) => (
+  <a
+    className={className}
+    href="https://wheelmap.org"
+    aria-label={t`Go to wheelmap.org`}
+    target="_blank"
+    rel="noreferrer noopener"
+  >
+    {/* translator: The alternative desription of the app logo for screenreaders */}
+    <img className="logo" src={logoURL} width={156} height={30} alt={t`App Logo`} />
+  </a>
+);
+
+const StyledWheelmapHomeLink = styled(WheelmapHomeLink)`
+  border-radius: 2px;
+  background-color: rgba(254, 254, 254, 0.8);
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+`;
+
+export default StyledWheelmapHomeLink;

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -104,14 +104,16 @@ export default class App extends BaseApp {
         localeStrings = getBrowserLocaleStrings();
       }
 
-      if (ctx.query.routeName) {
-        routeProps = await getInitialRouteProps(ctx.query, isServer);
-      }
-
-      appProps = await getInitialAppProps(
+      const appPropsPromise = getInitialAppProps(
         { userAgentString, hostName, localeStrings, ...ctx.query },
         isServer
       );
+
+      if (ctx.query.routeName) {
+        const routePropsPromise = getInitialRouteProps(ctx.query, isServer);
+        routeProps = await routePropsPromise;
+      }
+      appProps = await appPropsPromise;
 
       if (isServer) {
         ctx.res.set({ Vary: 'X-User-Agent-Variant, X-Locale-Variant' });

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const proxy = require('http-proxy-middleware');
 const cache = require('express-cache-headers');
 const compression = require('compression');
+const querystring = require('querystring');
 
 const router = require('./app/router');
 const env = require('./lib/env');
@@ -43,7 +44,13 @@ app.prepare().then(() => {
     }
   );
 
-  server.get([/(\/[a-zA-Z_-]+)?\/embed.*/], (req, res) => res.redirect('/?embedded=true'));
+  server.get([/(\/[a-zA-Z_-]+)?\/embed.*/], (req, res) => {
+    const extendedQueryString = querystring.stringify({
+      ...req.query,
+      embedded: true,
+    });
+    res.redirect(`/?${extendedQueryString}`);
+  });
 
   server.get('/:lang?/map', (req, res) => {
     const lang = req.param('lang');

--- a/src/server.js
+++ b/src/server.js
@@ -36,13 +36,14 @@ app.prepare().then(() => {
     [
       /(\/[a-zA-Z_-]+)?\/map\/.+/,
       /(\/[a-zA-Z_-]+)?\/community_support\/new.*/,
-      /(\/[a-zA-Z_-]+)?\/embed.*/,
       /(\/[a-zA-Z_-]+)?\/api\/docs.*/,
     ],
     (req, res) => {
       res.redirect(`http://classic.wheelmap.org${req.originalUrl}`);
     }
   );
+
+  server.get([/(\/[a-zA-Z_-]+)?\/embed.*/], (req, res) => res.redirect('/?embedded=true'));
 
   server.get('/:lang?/map', (req, res) => {
     const lang = req.param('lang');


### PR DESCRIPTION
Disclaimer: I couldn't find a more elegant way to deal with the differences of embedded vs non-embedded mode other than to just use conditionals throughout. Code is a little bit distributed, so I wasn't able to abstract it better.

This enables a wheelmap configuration with a query parameter `embedded=true`. When this is set Wheelmap changes in the following ways:

* The main menu is not displayed
* The search toolbar is not displayed
* The node toolbar is uses more space towards the top (since missing main menu and search toolbar opened up more space
* There is a Wheelmap home link that opens the full wheelmap site in a new tab now. The button is positioned on the right on wide viewports and on top for small viewports
* The previous redirect for the classic embed urls now instead redirects to the new wheelmap embed url