### PR TITLE
a11y Fixes to PhotosSection

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,21 @@ textarea {
     sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
+kbd {
+  background-color: #eee;
+  border-radius: 3px;
+  border: 1px solid #b4b4b4;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2), 0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
+  color: #333;
+  display: inline-block;
+  font-weight: 700;
+  line-height: 1;
+  padding: 2px 4px;
+  margin-left: 3px;
+  margin-right: 3px;
+  white-space: nowrap;
+}
+
 .ac-result-list,
 .ac-list {
   list-style-type: none;

--- a/src/components/NodeToolbar/Photos/PhotoSection.js
+++ b/src/components/NodeToolbar/Photos/PhotoSection.js
@@ -146,11 +146,15 @@ class PhotoSection extends React.Component<Props, State> {
 
     return [
       <section key="lightbox-actions" className={`lightbox-actions ${className}`}>
-        <button
-          disabled={!canReportPhoto}
-          onClick={this.reportImage}
-          className="report-image"
-        >{t`Report image`}</button>
+        <div>
+          <kbd>esc</kbd>
+          <kbd>⇦</kbd>
+          <kbd>⇨</kbd>
+        </div>
+
+        {canReportPhoto && (
+          <button onClick={this.reportImage} className="report-image">{t`Report image`}</button>
+        )}
       </section>,
     ];
   };
@@ -214,16 +218,15 @@ const StyledPhotoSection = styled(PhotoSection)`
   &.lightbox-actions {
     position: absolute;
     width: 100%;
-    /* Use same height as lightbox pagination */
-    height: 40px;
+    /* Use same height and positioning as lightbox pagination */
+    height: 30px;
     bottom: 0;
     margin: 0;
-    padding: 0;
+    padding: 5px 0;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
 
     button {
-      margin-top: 0.25rem;
       font-size: 0.9rem;
       font-weight: bold;
       color: white;
@@ -231,11 +234,22 @@ const StyledPhotoSection = styled(PhotoSection)`
       border: none;
       cursor: pointer;
       text-shadow: 0 1px 1px black;
+    }
 
-      /* Don't show button if you cannot interact with it */
-      &[disabled] {
-        display: none;
-      }
+    kbd {
+      background-color: #eee;
+      border-radius: 3px;
+      border: 1px solid #b4b4b4;
+      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2), 0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
+      color: #333;
+      display: inline-block;
+      font-size: 18px;
+      font-weight: 700;
+      line-height: 1;
+      padding: 2px 4px;
+      margin-left: 3px;
+      margin-right: 3px;
+      white-space: nowrap;
     }
   }
 `;

--- a/src/components/NodeToolbar/Photos/PhotoSection.js
+++ b/src/components/NodeToolbar/Photos/PhotoSection.js
@@ -73,6 +73,20 @@ class PhotoSection extends React.Component<Props, State> {
     }
   }
 
+  componentDidUpdate(_, prevState) {
+    if (!prevState.isLightboxOpen && this.state.isLightboxOpen) {
+      window.addEventListener('keydown', this.preventTabbing);
+    } else if (prevState.isLightboxOpen && !this.state.isLightboxOpen) {
+      window.removeEventListener('keydown', this.preventTabbing);
+    }
+  }
+
+  preventTabbing(event: KeyboardEvent) {
+    if (event.key === 'Tab' || event.keyCode === 9) {
+      event.preventDefault();
+    }
+  }
+
   photoSectionSelectedWithKeyboard = (event: KeyboardEvent) => {
     if (event.key === 'Enter' || event.keyCode === 'Enter') {
       this.thumbnailSelected(event, { index: 0 });

--- a/src/components/NodeToolbar/Photos/PhotoSection.js
+++ b/src/components/NodeToolbar/Photos/PhotoSection.js
@@ -239,19 +239,7 @@ const StyledPhotoSection = styled(PhotoSection)`
     }
 
     kbd {
-      background-color: #eee;
-      border-radius: 3px;
-      border: 1px solid #b4b4b4;
-      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2), 0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
-      color: #333;
-      display: inline-block;
       font-size: 18px;
-      font-weight: 700;
-      line-height: 1;
-      padding: 2px 4px;
-      margin-left: 3px;
-      margin-right: 3px;
-      white-space: nowrap;
     }
   }
 `;

--- a/src/components/NodeToolbar/Photos/PhotoSection.js
+++ b/src/components/NodeToolbar/Photos/PhotoSection.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react';
+import { findDOMNode } from 'react-dom';
 import { t } from 'ttag';
 import styled from 'styled-components';
 import Gallery from 'react-photo-gallery';
@@ -50,6 +51,33 @@ class PhotoSection extends React.Component<Props, State> {
 
     return { thumbnailPhotos };
   }
+
+  componentDidMount() {
+    // This manual event handling is necessary, because the lib react-gallery
+    // does not offer a keyDown API and only works with clicks.
+    // In order to make it keyboard-focusable and operable with the 'Enter' key,
+    // we add this functionality directly on the DOM node.
+    const photoSectionDOMNode = findDOMNode(this.gallery);
+
+    if (photoSectionDOMNode instanceof Element) {
+      photoSectionDOMNode.setAttribute('tabindex', '0');
+      photoSectionDOMNode.addEventListener('keydown', this.photoSectionSelectedWithKeyboard);
+    }
+  }
+
+  componentWillUnmount() {
+    const photoSectionDOMNode = findDOMNode(this.gallery);
+
+    if (photoSectionDOMNode instanceof Element) {
+      photoSectionDOMNode.removeEventListener('keydown', this.photoSectionSelectedWithKeyboard);
+    }
+  }
+
+  photoSectionSelectedWithKeyboard = (event: KeyboardEvent) => {
+    if (event.key === 'Enter' || event.keyCode === 'Enter') {
+      this.thumbnailSelected(event, { index: 0 });
+    }
+  };
 
   thumbnailSelected = (event: UIEvent, obj: { index: number }) => {
     this.openLightbox(event, obj);

--- a/src/components/NodeToolbar/Photos/PhotoSection.js
+++ b/src/components/NodeToolbar/Photos/PhotoSection.js
@@ -71,6 +71,8 @@ class PhotoSection extends React.Component<Props, State> {
     if (photoSectionDOMNode instanceof Element) {
       photoSectionDOMNode.removeEventListener('keydown', this.photoSectionSelectedWithKeyboard);
     }
+
+    window.removeEventListener('keydown', this.preventTabbing);
   }
 
   componentDidUpdate(_, prevState) {

--- a/src/components/NodeToolbar/Photos/PhotoSection.js
+++ b/src/components/NodeToolbar/Photos/PhotoSection.js
@@ -88,7 +88,7 @@ class PhotoSection extends React.Component<Props, State> {
   }
 
   photoSectionSelectedWithKeyboard = (event: KeyboardEvent) => {
-    if (event.key === 'Enter' || event.keyCode === 'Enter') {
+    if (event.key === 'Enter' || event.keyCode === 13) {
       this.thumbnailSelected(event, { index: 0 });
     }
   };


### PR DESCRIPTION
This fixes a few missing things for keyboard navigation:

* Tabbing now focuses the whole photo section and the lightbox can be opened with pressing the enter key.
* While the lightbox is open and showing the place photos, tabbing is disabled for the whole page. This prevents the focus from moving away in the background.
This is disabled on unmount and when the lightbox closes. I had to use a brute-force way like this, because react-images does not work with our `<FocusTrap>` component for complicated reasons :(
* I added some visual hint to how the lightbox is usable via Keyboard (Esc, ArrowLeft, ArrowRight)