### PR TITLE
Open External Content in New Tab (based on feat/add-create-route)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25279,6 +25279,15 @@
       "integrity": "sha1-56L3eE1cI09z3RFzs1TxyGviMXk=",
       "dev": true
     },
+    "react-ga": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.5.3.tgz",
+      "integrity": "sha512-25wvPv1PVLDLhw1gEYP33h0V2sJHahKMfUCAxhq8JPYmNQwx1fcjJAkJk+WmSqGN93lHLhExDkxy3SQizQnx3A==",
+      "requires": {
+        "prop-types": "15.6.2",
+        "react": "16.5.2"
+      }
+    },
     "react-images": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/react-images/-/react-images-0.5.19.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "glob": "^5.0.15",
     "humanize-string": "^1.0.1",
     "immutable": "^3.8.1",
+    "is-url": "^1.2.4",
     "isomorphic-unfetch": "^2.1.1",
     "leaflet": "^1.0.3",
     "leaflet-tilelayer-geojson": "^1.0.4",

--- a/scripts/createLinks.js
+++ b/scripts/createLinks.js
@@ -1,0 +1,43 @@
+const translations = require('../src/lib/translations.json');
+const get = require('lodash/get');
+
+function makeid() {
+  var text = '';
+  var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+  for (var i = 0; i < 13; i++) text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+  return text;
+}
+
+const links = [
+  {
+    appId: 'strut',
+    label: 'Add a new place',
+    url: 'https://ee.humanitarianresponse.info/x/#uZ9a6QQt',
+    order: 100,
+  },
+];
+
+const results = links.map((link, order) => {
+  const result = {
+    _id: makeid(),
+    appId: link.appId,
+    label: { en_US: link.label },
+    url: link.url,
+    order: link.order,
+  };
+
+  for (const lang in translations) {
+    const t = translations[lang];
+    const { label } = result;
+    const translation = get(translations, [lang, 'translations', '', label, 'msgstr', 0]);
+    if (translation && translation !== label) {
+      result.label[t.headers.language] = translation;
+    }
+  }
+
+  return result;
+});
+
+console.log(JSON.stringify(results, null, 4));

--- a/scripts/createLinks.js
+++ b/scripts/createLinks.js
@@ -13,6 +13,48 @@ function makeid() {
 const links = [
   {
     appId: 'strut',
+    label: 'Start Mapping',
+    url: 'http://www.strutcanada.com/start-mapping',
+    order: 0,
+  },
+  {
+    appId: 'strut',
+    label: 'How to use',
+    url: 'http://www.strutcanada.com/how-to-use',
+    order: 1,
+  },
+  {
+    appId: 'strut',
+    label: 'Get Involved',
+    url: 'http://www.strutcanada.com/volunteer-form',
+    order: 2,
+  },
+  {
+    appId: 'strut',
+    label: 'News',
+    url: 'http://www.strutcanada.com/',
+    order: 3,
+  },
+  {
+    appId: 'strut',
+    label: 'Publications',
+    url: 'http://www.strutcanada.com/#publications',
+    order: 3,
+  },
+  {
+    appId: 'strut',
+    label: 'ARC',
+    url: 'http://www.strutcanada.com/arc',
+    order: 3,
+  },
+  {
+    appId: 'strut',
+    label: 'About CAF',
+    url: 'http://www.strutcanada.com/caf',
+    order: 3,
+  },
+  {
+    appId: 'strut',
     label: 'Add a new place',
     url: 'https://ee.humanitarianresponse.info/x/#uZ9a6QQt',
     order: 100,

--- a/src/App.js
+++ b/src/App.js
@@ -142,13 +142,18 @@ class App extends React.Component<Props, State> {
       isSearchBarVisible: isStickySearchBarSupported(),
     };
 
-    // close search results when leaving search route
+    // open search results on search route
     if (props.routeName === 'search') {
       newState.isSearchToolbarExpanded = true;
       newState.isSearchBarVisible = true;
     }
 
-    if (props.routeName === 'place_detail' || props.routeName === 'equipment') {
+    if (props.routeName === 'createPlace' && state.modalNodeState !== 'create') {
+      newState.modalNodeState = 'create';
+      trackModalView('create');
+    }
+
+    if (props.routeName === 'placeDetail' || props.routeName === 'equipment') {
       const { accessibilityFilter, toiletFilter, category } = props;
 
       newState.isSearchBarVisible =
@@ -259,7 +264,7 @@ class App extends React.Component<Props, State> {
     const { routerHistory } = this.props;
 
     // show equipment inside their place details
-    let routeName = 'place_detail';
+    let routeName = 'placeDetail';
     const params = this.getCurrentParams();
 
     params.id = featureId;
@@ -304,7 +309,7 @@ class App extends React.Component<Props, State> {
       if (id) {
         params.id = id;
         delete params.eid;
-        routeName = 'place_detail';
+        routeName = 'placeDetail';
       }
     }
 
@@ -575,11 +580,6 @@ class App extends React.Component<Props, State> {
     this.gotoCurrentFeature();
   };
 
-  onAddMissingPlaceClick = () => {
-    this.setState({ modalNodeState: 'create' });
-    trackModalView('create');
-  };
-
   onSelectWheelchairAccessibility = (value: YesNoLimitedUnknown) => {
     if (this.props.featureId) {
       this.setState({
@@ -717,7 +717,6 @@ class App extends React.Component<Props, State> {
           onSelectWheelchairAccessibility={this.onSelectWheelchairAccessibility}
           onCloseWheelchairAccessibility={this.onCloseWheelchairAccessibility}
           onCloseToiletAccessibility={this.onCloseToiletAccessibility}
-          onAddMissingPlaceClick={this.onAddMissingPlaceClick}
           onSearchQueryChange={this.onSearchQueryChange}
           onEquipmentSelected={this.onEquipmentSelected}
           onShowPlaceDetails={this.showSelectedFeature}

--- a/src/App.js
+++ b/src/App.js
@@ -148,7 +148,7 @@ class App extends React.Component<Props, State> {
       newState.isSearchBarVisible = true;
     }
 
-    if (props.routeName === 'createPlace' && state.modalNodeState !== 'create') {
+    if (props.routeName === 'createPlace') {
       newState.modalNodeState = 'create';
       trackModalView('create');
     } else {

--- a/src/App.js
+++ b/src/App.js
@@ -46,7 +46,7 @@ import { trackModalView } from './lib/Analytics';
 
 initReactFastclick();
 
-export type Link = {
+export type LinkData = {
   label: LocalizedString,
   url: LocalizedString,
   order?: number,

--- a/src/App.js
+++ b/src/App.js
@@ -151,6 +151,8 @@ class App extends React.Component<Props, State> {
     if (props.routeName === 'createPlace' && state.modalNodeState !== 'create') {
       newState.modalNodeState = 'create';
       trackModalView('create');
+    } else {
+      newState.modalNodeState = null;
     }
 
     if (props.routeName === 'placeDetail' || props.routeName === 'equipment') {
@@ -521,6 +523,11 @@ class App extends React.Component<Props, State> {
     }
   };
 
+  onCloseCreatePlaceDialog = () => {
+    const params = this.getCurrentParams();
+    this.props.routerHistory.push('map', params);
+  };
+
   onCloseOnboarding = () => {
     saveState({ onboardingCompleted: 'true' });
     this.setState({ isOnboardingVisible: false });
@@ -711,7 +718,7 @@ class App extends React.Component<Props, State> {
           onSearchToolbarClick={this.onSearchToolbarClick}
           onSearchToolbarClose={this.onSearchToolbarClose}
           onSearchToolbarSubmit={this.onSearchToolbarSubmit}
-          onCloseCreatePlaceDialog={this.onCloseNodeToolbar}
+          onCloseCreatePlaceDialog={this.onCloseCreatePlaceDialog}
           onOpenWheelchairAccessibility={this.onOpenWheelchairAccessibility}
           onOpenToiletAccessibility={this.onOpenToiletAccessibility}
           onSelectWheelchairAccessibility={this.onSelectWheelchairAccessibility}

--- a/src/App.js
+++ b/src/App.js
@@ -151,7 +151,9 @@ class App extends React.Component<Props, State> {
     if (props.routeName === 'createPlace') {
       newState.modalNodeState = 'create';
       trackModalView('create');
-    } else {
+    }
+
+    if (props.routeName === 'map') {
       newState.modalNodeState = null;
     }
 

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -105,7 +105,6 @@ type Props = {
   onOpenToiletAccessibility: () => void,
   onCloseWheelchairAccessibility: () => void,
   onCloseToiletAccessibility: () => void,
-  onAddMissingPlaceClick: () => void,
   onSearchQueryChange: (searchQuery: string) => void,
   onEquipmentSelected: (placeInfoId: string, equipmentInfo: EquipmentInfo) => void,
   onShowPlaceDetails: (featureId: string | number) => void,
@@ -354,7 +353,6 @@ class MainView extends React.Component<Props, State> {
         onToggle={this.props.onToggleMainMenu}
         onHomeClick={this.props.onMainMenuHomeClick}
         isLocalizationLoaded={this.props.isLocalizationLoaded}
-        onAddMissingPlaceClick={this.props.onAddMissingPlaceClick}
         logoURL={logoURL}
         claim={textContent.product.claim}
         links={customMainMenuLinks}

--- a/src/app/CreatePlaceData.js
+++ b/src/app/CreatePlaceData.js
@@ -1,0 +1,16 @@
+// @flow
+
+import React from 'react';
+
+import { type DataTableEntry } from './getInitialProps';
+import { t } from 'ttag';
+
+type CreatePlaceProps = {};
+
+const CreatePlaceData: DataTableEntry<CreatePlaceProps> = {
+  getHead(props) {
+    return <title key="title">{t`Add a new place`}</title>;
+  },
+};
+
+export default CreatePlaceData;

--- a/src/app/PlaceDetailsData.js
+++ b/src/app/PlaceDetailsData.js
@@ -247,7 +247,7 @@ const PlaceDetailsData: DataTableEntry<PlaceDetailsProps> = {
 
         extras.push(
           <meta
-            content={router.generatePath('place_detail', { id: getFeatureId(feature) })}
+            content={router.generatePath('placeDetail', { id: getFeatureId(feature) })}
             property="og:url"
             key="og:url"
           />

--- a/src/app/getInitialProps.js
+++ b/src/app/getInitialProps.js
@@ -22,6 +22,7 @@ import { categoriesCache } from '../lib/cache/CategoryLookupTablesCache';
 import SearchData from './SearchData';
 import PlaceDetailsData from './PlaceDetailsData';
 import MapData from './MapData';
+import CreatePlaceData from './CreatePlaceData';
 
 export type AppProps = {
   userAgent: UAResult,
@@ -63,6 +64,7 @@ const dataTable: DataTable = Object.freeze({
   search: SearchData,
   map: MapData,
   equipment: PlaceDetailsData,
+  createPlace: CreatePlaceData,
 });
 
 export function getInitialRouteProps(

--- a/src/app/getInitialProps.js
+++ b/src/app/getInitialProps.js
@@ -59,7 +59,7 @@ type DataTable = {
 };
 
 const dataTable: DataTable = Object.freeze({
-  place_detail: PlaceDetailsData,
+  placeDetail: PlaceDetailsData,
   search: SearchData,
   map: MapData,
   equipment: PlaceDetailsData,

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -2,7 +2,7 @@ const Router = require('../lib/Router');
 
 const routes = [
   {
-    name: 'place_detail',
+    name: 'placeDetail',
     path: '/nodes/:id',
   },
   {
@@ -16,6 +16,10 @@ const routes = [
   {
     name: 'categories',
     path: '/categories/:category',
+  },
+  {
+    name: 'addPlace',
+    path: '/add-place',
   },
   {
     name: 'map',

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -18,7 +18,7 @@ const routes = [
     path: '/categories/:category',
   },
   {
-    name: 'addPlace',
+    name: 'createPlace',
     path: '/add-place',
   },
   {

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -66,7 +66,7 @@ class Link extends React.Component<Props> {
   };
 
   renderExternalLink = (to: string) => (
-    <a {...this.props} href={to}>
+    <a {...this.props} href={to} target="_blank" rel="noopener noreferrer">
       {this.props.children}
     </a>
   );

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -40,23 +40,27 @@ class Link extends React.Component<Props> {
   }
 
   renderInternalLink = (routeName: string) => {
-    const { params, children, ...props } = this.props;
+    const { children, ...props } = this.props;
 
     delete props.replace;
 
     return (
       <RouteConsumer>
-        {(context: RouteContext) => (
-          <a
-            {...props}
-            href={context.history.generatePath(routeName, context.params)}
-            onClick={(event: SyntheticEvent<HTMLLinkElement>) => {
-              this.handleClick(routeName, context.history, context.params, event);
-            }}
-          >
-            {children}
-          </a>
-        )}
+        {(context: RouteContext) => {
+          const params = this.props.params || context.params;
+
+          return (
+            <a
+              {...props}
+              href={context.history.generatePath(routeName, params)}
+              onClick={(event: SyntheticEvent<HTMLLinkElement>) => {
+                this.handleClick(routeName, context.history, params, event);
+              }}
+            >
+              {children}
+            </a>
+          );
+        }}
       </RouteConsumer>
     );
   };
@@ -76,7 +80,9 @@ class Link extends React.Component<Props> {
       return this.renderInternalLink(to);
     }
 
-    return null;
+    throw new Error(
+      'Failed to create Link component: `to` property was not a URL, route path or route name'
+    );
   }
 }
 

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { createContext, Component } from 'react';
+import React, { Component } from 'react';
 
 import { type RouterHistory, type RouteParams } from '../../lib/RouterHistory';
 import { type RouteContext, RouteConsumer, RouteProvider } from './RouteContext';
@@ -44,6 +44,7 @@ class Link extends Component<Props> {
     delete props.replace;
 
     return (
+      // eslint-disable-next-line jsx-a11y/anchor-has-content
       <a
         {...props}
         href={href}

--- a/src/components/MainMenu/MainMenu.js
+++ b/src/components/MainMenu/MainMenu.js
@@ -19,7 +19,6 @@ type State = {
 type Props = {
   className: string,
   onToggle: (isMainMenuOpen: boolean) => void,
-  onAddMissingPlaceClick: () => void,
   onHomeClick: () => void,
   isOpen: boolean,
   lat: string,

--- a/src/components/MainMenu/MainMenu.js
+++ b/src/components/MainMenu/MainMenu.js
@@ -9,8 +9,9 @@ import CloseIcon from '../icons/actions/Close';
 import colors from '../../lib/colors';
 import { t } from 'ttag';
 import GlobalActivityIndicator from './GlobalActivityIndicator';
-import type { Link } from '../../App';
+import type { LinkData } from '../../App';
 import { translatedStringFromObject, type LocalizedString } from '../../lib/i18n';
+import Link, { RouteConsumer } from '../Link/Link';
 
 type State = {
   isMenuButtonVisible: boolean,
@@ -26,7 +27,7 @@ type Props = {
   zoom: string,
   logoURL: string,
   claim: LocalizedString,
-  links: Array<Link>,
+  links: Array<LinkData>,
 };
 
 function MenuIcon(props) {
@@ -123,6 +124,19 @@ class MainMenu extends React.Component<Props, State> {
       const label = translatedStringFromObject(link.label);
       const classNamesFromTags = link.tags && link.tags.map(tag => `${tag}-link`);
       const className = ['nav-link'].concat(classNamesFromTags).join(' ');
+
+      if (url && url === '/add-place') {
+        return (
+          <RouteConsumer>
+            {context => (
+              <Link routeName="createPlace" params={context.params}>
+                {label}
+              </Link>
+            )}
+          </RouteConsumer>
+        );
+      }
+
       return (
         <a key={url} className={className} href={url} role="menuitem">
           {label}

--- a/src/components/MainMenu/MainMenu.js
+++ b/src/components/MainMenu/MainMenu.js
@@ -129,7 +129,7 @@ class MainMenu extends React.Component<Props, State> {
         return (
           <RouteConsumer>
             {context => (
-              <Link routeName="createPlace" params={context.params}>
+              <Link key={url} routeName="createPlace" params={context.params}>
                 {label}
               </Link>
             )}

--- a/src/components/MainMenu/MainMenu.js
+++ b/src/components/MainMenu/MainMenu.js
@@ -125,23 +125,13 @@ class MainMenu extends React.Component<Props, State> {
       const classNamesFromTags = link.tags && link.tags.map(tag => `${tag}-link`);
       const className = ['nav-link'].concat(classNamesFromTags).join(' ');
 
-      if (url && url === '/add-place') {
+      if (typeof url === 'string') {
         return (
-          <RouteConsumer>
-            {context => (
-              <Link key={url} routeName="createPlace" params={context.params}>
-                {label}
-              </Link>
-            )}
-          </RouteConsumer>
+          <Link key={url} className={className} to={url} role="menuitem">
+            {label}
+          </Link>
         );
       }
-
-      return (
-        <a key={url} className={className} href={url} role="menuitem">
-          {label}
-        </a>
-      );
     });
   }
 

--- a/src/components/MainMenu/MainMenu.js
+++ b/src/components/MainMenu/MainMenu.js
@@ -27,7 +27,6 @@ type Props = {
   logoURL: string,
   claim: LocalizedString,
   links: Array<Link>,
-  addPlaceURL: string,
 };
 
 function MenuIcon(props) {

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -845,14 +845,22 @@ export default class Map extends React.Component<Props, State> {
         </a>
         <span className="mapbox-attribution-container">
           <span className="sozialhelden-logo-container">
-            <a href="https://www.sozialhelden.de">
+            <a href="https://www.sozialhelden.de" target="_blank" rel="noopener noreferrer">
               <SozialheldenLogo />
               &nbsp;|&nbsp;
             </a>
           </span>
-          <a href="https://www.mapbox.com/about/maps/">© Mapbox |</a>
+          <a href="https://www.mapbox.com/about/maps/" target="_blank" rel="noopener noreferrer">
+            © Mapbox |
+          </a>
           &nbsp;
-          <a href="http://www.openstreetmap.org/copyright">© OpenStreetMap |</a>
+          <a
+            href="http://www.openstreetmap.org/copyright"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            © OpenStreetMap |
+          </a>
           &nbsp;
           <a href="https://www.mapbox.com/map-feedback/" target="_blank" rel="noopener noreferrer">
             <strong>Improve this map</strong>

--- a/src/components/NodeToolbar/Report/FixComment.js
+++ b/src/components/NodeToolbar/Report/FixComment.js
@@ -74,6 +74,8 @@ export default class ReportProblemButton extends React.Component<Props> {
           className="link-button"
           ref={editLink => (this.editLink = editLink)}
           onKeyDown={this.trapFocus}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {editButtonCaption}
         </a>
@@ -82,6 +84,8 @@ export default class ReportProblemButton extends React.Component<Props> {
           className="link-button"
           ref={noteLink => (this.noteLink = noteLink)}
           onKeyDown={this.trapFocus}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {noteButtonCaption}
         </a>

--- a/src/components/NodeToolbar/Report/FixNonExistingPlace.js
+++ b/src/components/NodeToolbar/Report/FixNonExistingPlace.js
@@ -82,6 +82,8 @@ export default class ReportProblemButton extends React.Component<Props> {
           <a
             href="https://wiki.openstreetmap.org/wiki/Key:disused:"
             ref={howToLink => (this.howToLink = howToLink)}
+            target="_blank"
+            rel="noopener noreferrer"
           >
             {osmPermanentlyClosedHowtoLinkCaption}
           </a>
@@ -95,6 +97,8 @@ export default class ReportProblemButton extends React.Component<Props> {
           className="link-button"
           ref={editLink => (this.editLink = editLink)}
           onKeyDown={this.trapFocus}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {editButtonCaption}
         </a>
@@ -103,6 +107,8 @@ export default class ReportProblemButton extends React.Component<Props> {
           className="link-button"
           ref={noteLink => (this.noteLink = noteLink)}
           onKeyDown={this.trapFocus}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {noteButtonCaption}
         </a>

--- a/src/components/NodeToolbar/Report/FixPlacePosition.js
+++ b/src/components/NodeToolbar/Report/FixPlacePosition.js
@@ -67,6 +67,8 @@ export default class ReportProblemButton extends React.Component<Props> {
           className="link-button"
           ref={editLink => (this.editLink = editLink)}
           onKeyDown={this.trapFocus}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {editButtonCaption}
         </a>
@@ -75,6 +77,8 @@ export default class ReportProblemButton extends React.Component<Props> {
           className="link-button"
           ref={noteLink => (this.noteLink = noteLink)}
           onKeyDown={this.trapFocus}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {noteButtonCaption}
         </a>

--- a/src/components/SearchToolbar/CategoryButton.js
+++ b/src/components/SearchToolbar/CategoryButton.js
@@ -58,7 +58,7 @@ function CategoryButton(props: Props) {
         return (
           <Link
             params={params}
-            routeName={context.name}
+            to={context.name}
             aria-label={showCloseButton ? t`Remove ${props.name} Filter` : props.name}
             className={className}
             onFocus={props.onFocus}

--- a/src/lib/Router.js
+++ b/src/lib/Router.js
@@ -80,11 +80,10 @@ class Router {
     return { params, query };
   }
 
-  getRoute(name, strict = false) {
-    const route = this.routes.find(route => route.name === name);
-
+  getRoute(nameOrPath, strict = false) {
+    const route = this.routes.find(route => route.name === nameOrPath || route.path === nameOrPath);
     if (strict && !route) {
-      throw new Error(`Unknown route: ${name}.`);
+      throw new Error(`Unknown route: ${nameOrPath}.`);
     }
 
     return route;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7627,7 +7627,7 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-url@^1.2.1:
+is-url@^1.2.1, is-url@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
   integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==


### PR DESCRIPTION
This branch is based on the `feat/add-create-route` branch, because there were some changes to the way the main menu was rendered in the latter.

This makes all links to external pages open in new tabs so that the user doesn't not lose the app state and everything has to reload when they hit the back button.

