### PR TITLE
Added support for displaying toilets nearby

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -659,6 +659,7 @@ class App extends React.Component<Props, State> {
       equipmentInfoId: this.props.equipmentInfoId,
       equipmentInfo: this.props.equipmentInfo,
       photos: this.props.photos,
+      toiletsNearby: this.props.toiletsNearby,
       category: this.props.category,
       categories: this.props.categories,
       sources: this.props.sources,

--- a/src/App.js
+++ b/src/App.js
@@ -579,6 +579,13 @@ class App extends React.Component<Props, State> {
     }
   };
 
+  onOpenToiletNearby = (feature: Feature) => {
+    if (feature) {
+      const featureId = feature.id || feature.properties.id || feature.properties._id;
+      this.showSelectedFeature(featureId);
+    }
+  };
+
   gotoCurrentFeature() {
     if (this.props.featureId) {
       this.setState({ modalNodeState: null });
@@ -729,6 +736,7 @@ class App extends React.Component<Props, State> {
           onCloseModalDialog={this.onCloseModalDialog}
           onOpenWheelchairAccessibility={this.onOpenWheelchairAccessibility}
           onOpenToiletAccessibility={this.onOpenToiletAccessibility}
+          onOpenToiletNearby={this.onOpenToiletNearby}
           onSelectWheelchairAccessibility={this.onSelectWheelchairAccessibility}
           onCloseWheelchairAccessibility={this.onCloseWheelchairAccessibility}
           onCloseToiletAccessibility={this.onCloseToiletAccessibility}

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -245,6 +245,7 @@ class MainView extends React.Component<Props, State> {
           userAgent={this.props.userAgent}
           onOpenWheelchairAccessibility={this.props.onOpenWheelchairAccessibility}
           onOpenToiletAccessibility={this.props.onOpenToiletAccessibility}
+          onOpenToiletNearby={this.props.onOpenToiletNearby}
           onSelectWheelchairAccessibility={this.props.onSelectWheelchairAccessibility}
           onCloseWheelchairAccessibility={this.props.onCloseWheelchairAccessibility}
           onCloseToiletAccessibility={this.props.onCloseToiletAccessibility}

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -241,6 +241,7 @@ class MainView extends React.Component<Props, State> {
           categories={this.props.categories}
           sources={this.props.sources}
           photos={this.props.photos}
+          toiletsNearby={this.props.toiletsNearby}
           userAgent={this.props.userAgent}
           onOpenWheelchairAccessibility={this.props.onOpenWheelchairAccessibility}
           onOpenToiletAccessibility={this.props.onOpenToiletAccessibility}

--- a/src/app/PlaceDetailsData.js
+++ b/src/app/PlaceDetailsData.js
@@ -125,7 +125,7 @@ function fetchPhotos(
 }
 
 const PlaceDetailsData: DataTableEntry<PlaceDetailsProps> = {
-  async getInitialRouteProps(query, isServer): Promise<PlaceDetailsProps> {
+  async getInitialRouteProps(query, appPropsPromise, isServer): Promise<PlaceDetailsProps> {
     const featureId = query.id;
     const equipmentInfoId = query.eid;
 

--- a/src/app/PlaceDetailsData.js
+++ b/src/app/PlaceDetailsData.js
@@ -165,11 +165,7 @@ const PlaceDetailsData: DataTableEntry<PlaceDetailsProps> = {
         ? wheelmapLightweightFeatureCache.getCachedFeature(featureId)
         : null;
       const sourcesPromise = fetchSourceWithLicense(featureId, featurePromise, useCache);
-
       const toiletsNearbyPromise = fetchToiletsNearby(appPropsPromise, featurePromise);
-      if (toiletsNearbyPromise) {
-        toiletsNearbyPromise.then(console.log);
-      }
 
       const feature = isServer ? await featurePromise : featurePromise;
       const equipmentInfo = (isServer ? await equipmentPromise : equipmentPromise) || null;

--- a/src/app/PlaceDetailsProps.js
+++ b/src/app/PlaceDetailsProps.js
@@ -45,6 +45,8 @@ export type PlaceDetailsProps = {
   equipmentInfoId: ?string,
   // the equimentInfo
   equipmentInfo: ?PotentialPromise<EquipmentInfo>,
+  // toilets around the selected feature
+  toiletsNearby: ?PotentialPromise<Feature[]>,
 };
 
 export type ResolvedPlaceDetailsProps = {
@@ -62,6 +64,8 @@ export type ResolvedPlaceDetailsProps = {
   equipmentInfoId: ?string,
   // the equimentInfo
   equipmentInfo: ?EquipmentInfo,
+  // toilets around the selected feature
+  toiletsNearby: ?(Feature[]),
 };
 
 export function getPlaceDetailsIfAlreadyResolved(
@@ -73,11 +77,15 @@ export function getPlaceDetailsIfAlreadyResolved(
   const resolvedEquimentInfo = props.equipmentInfo
     ? getDataIfAlreadyResolved(props.equipmentInfo)
     : null;
+  const resolvedToiletsNearby = props.toiletsNearby
+    ? getDataIfAlreadyResolved(props.toiletsNearby)
+    : null;
 
   if (
     !resolvedSources ||
     !resolvedFeature ||
     (props.equipmentInfo && !resolvedEquimentInfo) ||
+    (props.toiletsNearby && !resolvedToiletsNearby) ||
     !resolvedPhotos
   ) {
     return null;
@@ -91,6 +99,7 @@ export function getPlaceDetailsIfAlreadyResolved(
     photos: resolvedPhotos,
     equipmentInfoId: props.equipmentInfoId,
     equipmentInfo: resolvedEquimentInfo,
+    toiletsNearby: resolvedToiletsNearby,
   };
 }
 
@@ -103,6 +112,9 @@ export async function awaitPlaceDetails(
   const resolvedEquipmentInfo = props.equipmentInfo
     ? await getDataPromise(props.equipmentInfo)
     : null;
+  const resolvedToiletsNearby = props.toiletsNearby
+    ? await getDataPromise(props.toiletsNearby)
+    : null;
 
   return {
     lightweightFeature: props.lightweightFeature,
@@ -112,5 +124,6 @@ export async function awaitPlaceDetails(
     photos: resolvedPhotos,
     equipmentInfoId: props.equipmentInfoId,
     equipmentInfo: resolvedEquipmentInfo,
+    toiletsNearby: resolvedToiletsNearby,
   };
 }

--- a/src/app/SearchData.js
+++ b/src/app/SearchData.js
@@ -63,7 +63,7 @@ async function fetchWheelmapNode(
 }
 
 const SearchData: DataTableEntry<SearchProps> = {
-  async getInitialRouteProps(query, isServer) {
+  async getInitialRouteProps(query, appProps, isServer) {
     const searchQuery = query.q;
 
     let trimmedSearchQuery;

--- a/src/app/getInitialProps.js
+++ b/src/app/getInitialProps.js
@@ -50,7 +50,11 @@ type DataTableQuery = {
 };
 
 export type DataTableEntry<Props> = {
-  getInitialRouteProps?: (query: DataTableQuery, isServer: boolean) => Promise<Props>,
+  getInitialRouteProps?: (
+    query: DataTableQuery,
+    appPropsPromise: Promise<AppProps>,
+    isServer: boolean
+  ) => Promise<Props>,
   getRenderProps?: (props: Props, isServer: boolean) => Props,
   getHead?: (props: Props & AppProps) => Promise<React$Element<any>> | React$Element<any>,
   storeInitialRouteProps?: (props: Props) => void,
@@ -77,6 +81,7 @@ export function getInitialRouteProps(
     routeName: string,
     [key: string]: string,
   },
+  appPropsPromise: Promise<AppProps>,
   isServer: boolean
 ) {
   const dataItem = dataTable[routeName];
@@ -85,7 +90,7 @@ export function getInitialRouteProps(
     return {};
   }
 
-  return dataItem.getInitialRouteProps(query, isServer);
+  return dataItem.getInitialRouteProps(query, appPropsPromise, isServer);
 }
 
 export function getRenderProps<Props>(routeName: string, props: Props, isServer: boolean): Props {

--- a/src/components/Map/getAccessibilityCloudTileUrl.js
+++ b/src/components/Map/getAccessibilityCloudTileUrl.js
@@ -3,13 +3,10 @@ import env from '../../lib/env';
 
 import { type Locale } from '../../lib/i18n';
 
-export default function accessibilityCloudTileUrl(
-  locale: Locale,
+export function buildSourceIdParams(
   includeSourceIds: Array<string>,
   excludeSourceIds: Array<string>
 ): string {
-  const acLocaleString = locale.underscoredString;
-
   // always do not show wheelmap source, but all other sources
   const wheelmapSourceId = 'LiBTS67TjmBcXdEmX';
 
@@ -22,6 +19,17 @@ export default function accessibilityCloudTileUrl(
   } else {
     sourceIdParams = `excludeSourceIds=${wheelmapSourceId}`;
   }
+
+  return sourceIdParams;
+}
+
+export default function accessibilityCloudTileUrl(
+  locale: Locale,
+  includeSourceIds: Array<string>,
+  excludeSourceIds: Array<string>
+): string {
+  const acLocaleString = locale.underscoredString;
+  const sourceIdParams = buildSourceIdParams(includeSourceIds, excludeSourceIds);
 
   return `${
     env.public.accessibilityCloud.baseUrl.cached

--- a/src/components/NodeToolbar/AccessibilitySection/AccessibleDescription.js
+++ b/src/components/NodeToolbar/AccessibilitySection/AccessibleDescription.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react';
+import Description from './Description';
 
 interface AccessibleDescriptionInterface {
   description?: string;
@@ -22,11 +23,14 @@ export default function AccessibleDescription(props: Props) {
   const properties = props.properties;
   if (!properties) return null;
   const { description, longDescription, shortDescription } = properties;
-  if (!description && !longDescription && !shortDescription) return null;
+
+  const descriptionText = shortDescription || description || longDescription;
+
+  if (!descriptionText) return null;
 
   return (
-    <p className={props.className} aria-label={longDescription || description || shortDescription}>
-      {shortDescription || description || longDescription}
-    </p>
+    <Description className={props.className} aria-label={descriptionText}>
+      {descriptionText}
+    </Description>
   );
 }

--- a/src/components/NodeToolbar/AccessibilitySection/Description.js
+++ b/src/components/NodeToolbar/AccessibilitySection/Description.js
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+const Description = styled.footer.attrs({ className: 'description' })`
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem !important;
+  padding-left: 8px;
+  border-left: 2px solid rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  color: rgba(0, 0, 0, 0.6);
+  quotes: '“', '”';
+
+  &:before {
+    color: rgba(0, 0, 0, 0.8);
+    content: open-quote;
+  }
+
+  &:after {
+    color: rgba(0, 0, 0, 0.8);
+    content: close-quote;
+  }
+`;
+
+export default Description;

--- a/src/components/NodeToolbar/AccessibilitySection/PlaceAccessibilitySection.js
+++ b/src/components/NodeToolbar/AccessibilitySection/PlaceAccessibilitySection.js
@@ -25,6 +25,7 @@ type Props = {
   onSelectWheelchairAccessibility: (value: YesNoLimitedUnknown) => void,
   onOpenWheelchairAccessibility: () => void,
   onOpenToiletAccessibility: () => void,
+  onOpenToiletNearby: (feature: Feature) => void,
   presetStatus: ?YesNoLimitedUnknown,
   feature: ?Feature,
   toiletsNearby: ?(Feature[]),
@@ -70,6 +71,7 @@ export default function PlaceAccessibilitySection(props: Props) {
         toiletsNearby={toiletsNearby}
         onOpenWheelchairAccessibility={props.onOpenWheelchairAccessibility}
         onOpenToiletAccessibility={props.onOpenToiletAccessibility}
+        onOpenToiletNearby={props.onOpenToiletNearby}
       />
       {description && descriptionElement}
       <AccessibleDescription properties={properties} />

--- a/src/components/NodeToolbar/AccessibilitySection/PlaceAccessibilitySection.js
+++ b/src/components/NodeToolbar/AccessibilitySection/PlaceAccessibilitySection.js
@@ -26,8 +26,8 @@ type Props = {
   onOpenWheelchairAccessibility: () => void,
   onOpenToiletAccessibility: () => void,
   presetStatus: ?YesNoLimitedUnknown,
-  // history: RouterHistory,
   feature: ?Feature,
+  toiletsNearby: ?(Feature[]),
 };
 
 const Description = styled.footer.attrs({ className: 'description' })`
@@ -36,7 +36,7 @@ const Description = styled.footer.attrs({ className: 'description' })`
 `;
 
 export default function PlaceAccessibilitySection(props: Props) {
-  const { featureId, feature } = props;
+  const { featureId, feature, toiletsNearby } = props;
   const properties = feature && feature.properties;
   const wheelmapFeature = wheelmapFeatureFrom(feature);
   const isWheelmapFeature = isWheelmapFeatureId(featureId);
@@ -67,6 +67,7 @@ export default function PlaceAccessibilitySection(props: Props) {
       <WheelchairAndToiletAccessibility
         isEditingEnabled={isWheelmapFeature}
         feature={feature}
+        toiletsNearby={toiletsNearby}
         onOpenWheelchairAccessibility={props.onOpenWheelchairAccessibility}
         onOpenToiletAccessibility={props.onOpenToiletAccessibility}
       />

--- a/src/components/NodeToolbar/AccessibilitySection/PlaceAccessibilitySection.js
+++ b/src/components/NodeToolbar/AccessibilitySection/PlaceAccessibilitySection.js
@@ -13,11 +13,7 @@ import type { Feature } from '../../../lib/Feature';
 import type { YesNoLimitedUnknown } from '../../../lib/Feature';
 import type { Category } from '../../../lib/Categories';
 import filterAccessibility from '../../../lib/filterAccessibility';
-import {
-  isWheelmapFeatureId,
-  wheelmapFeatureFrom,
-  isWheelchairAccessible,
-} from '../../../lib/Feature';
+import { isWheelmapFeatureId } from '../../../lib/Feature';
 
 type Props = {
   featureId: ?string | number,
@@ -39,15 +35,7 @@ const Description = styled.footer.attrs({ className: 'description' })`
 export default function PlaceAccessibilitySection(props: Props) {
   const { featureId, feature, toiletsNearby } = props;
   const properties = feature && feature.properties;
-  const wheelmapFeature = wheelmapFeatureFrom(feature);
   const isWheelmapFeature = isWheelmapFeatureId(featureId);
-  if (
-    wheelmapFeature &&
-    wheelmapFeature.properties &&
-    isWheelchairAccessible(wheelmapFeature.properties) === 'unknown'
-  ) {
-    return null;
-  }
 
   const accessibilityTree =
     properties && typeof properties.accessibility === 'object' ? properties.accessibility : null;

--- a/src/components/NodeToolbar/AccessibilitySection/PlaceAccessibilitySection.js
+++ b/src/components/NodeToolbar/AccessibilitySection/PlaceAccessibilitySection.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from 'react';
-import styled from 'styled-components';
 
 import StyledFrame from './StyledFrame';
 import AccessibilityDetailsTree from './AccessibilityDetailsTree';
@@ -14,6 +13,7 @@ import type { YesNoLimitedUnknown } from '../../../lib/Feature';
 import type { Category } from '../../../lib/Categories';
 import filterAccessibility from '../../../lib/filterAccessibility';
 import { isWheelmapFeatureId } from '../../../lib/Feature';
+import Description from './Description';
 
 type Props = {
   featureId: ?string | number,
@@ -26,11 +26,6 @@ type Props = {
   feature: ?Feature,
   toiletsNearby: ?(Feature[]),
 };
-
-const Description = styled.footer.attrs({ className: 'description' })`
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem !important;
-`;
 
 export default function PlaceAccessibilitySection(props: Props) {
   const { featureId, feature, toiletsNearby } = props;
@@ -49,7 +44,7 @@ export default function PlaceAccessibilitySection(props: Props) {
   if (properties && typeof properties.wheelchair_description === 'string') {
     description = properties.wheelchair_description;
   }
-  const descriptionElement = description ? <Description>“{description}”</Description> : null;
+  const descriptionElement = description ? <Description>{description}</Description> : null;
 
   return (
     <StyledFrame>

--- a/src/components/NodeToolbar/AccessibilitySection/StyledFrame.js
+++ b/src/components/NodeToolbar/AccessibilitySection/StyledFrame.js
@@ -12,6 +12,10 @@ const StyledFrame = styled.div`
   border: 1px solid ${colors.borderColor};
   border-radius: 4px;
 
+  &:empty {
+    display: none;
+  }
+
   &:before {
     display: block;
     position: absolute;

--- a/src/components/NodeToolbar/AccessibilitySection/WheelchairAndToiletAccessibility.js
+++ b/src/components/NodeToolbar/AccessibilitySection/WheelchairAndToiletAccessibility.js
@@ -136,7 +136,7 @@ class WheelchairAndToiletAccessibility extends React.Component<Props> {
   }
 
   render() {
-    const { feature } = this.props;
+    const { feature, toiletsNearby } = this.props;
     const { properties } = feature || {};
     if (!properties) {
       return null;
@@ -145,21 +145,24 @@ class WheelchairAndToiletAccessibility extends React.Component<Props> {
     const wheelchairAccessibility = isWheelchairAccessible(properties);
     const toiletAccessibility = hasAccessibleToilet(properties);
 
-    if (wheelchairAccessibility === 'unknown' && toiletAccessibility === 'unknown') {
-      return null;
-    }
-
+    const isKnownWheelchairAccessibility = wheelchairAccessibility !== 'unknown';
     const categoryId = getCategoryIdFromProperties(properties);
     const hasBlacklistedCategory = includes(placeCategoriesWithoutExtraToiletEntry, categoryId);
     const canAddToiletStatus =
       isWheelmapFeature(feature) && includes(['yes', 'limited'], wheelchairAccessibility);
-    const isToiletButtonShown = !hasBlacklistedCategory && canAddToiletStatus;
+    const isToiletButtonShown =
+      isKnownWheelchairAccessibility && !hasBlacklistedCategory && canAddToiletStatus;
 
-    const findToiletsNearby = toiletAccessibility !== 'yes';
+    const findToiletsNearby =
+      toiletAccessibility !== 'yes' && toiletsNearby && toiletsNearby.length > 0;
+    const hasContent = isKnownWheelchairAccessibility || isToiletButtonShown || findToiletsNearby;
+    if (!hasContent) {
+      return null;
+    }
 
     return (
       <div className={this.props.className}>
-        {this.renderWheelchairButton(wheelchairAccessibility)}
+        {isKnownWheelchairAccessibility && this.renderWheelchairButton(wheelchairAccessibility)}
         {isToiletButtonShown && this.renderToiletButton(toiletAccessibility)}
         {findToiletsNearby && this.renderNearbyToilets()}
       </div>

--- a/src/components/NodeToolbar/AccessibilitySection/WheelchairAndToiletAccessibility.js
+++ b/src/components/NodeToolbar/AccessibilitySection/WheelchairAndToiletAccessibility.js
@@ -65,6 +65,7 @@ function ToiletDescription(accessibility: YesNoUnknown) {
 
 type Props = {
   feature: Feature,
+  toiletsNearby: ?(Feature[]),
   onOpenWheelchairAccessibility: () => void,
   onOpenToiletAccessibility: () => void,
   className: string,
@@ -107,7 +108,7 @@ class WheelchairAndToiletAccessibility extends React.Component<Props> {
   }
 
   render() {
-    const { feature } = this.props;
+    const { feature, toiletsNearby } = this.props;
     const { properties } = feature || {};
     if (!properties) {
       return null;
@@ -115,6 +116,7 @@ class WheelchairAndToiletAccessibility extends React.Component<Props> {
 
     const wheelchairAccessibility = isWheelchairAccessible(properties);
     const toiletAccessibility = hasAccessibleToilet(properties);
+    console.log(toiletAccessibility, properties);
     if (wheelchairAccessibility === 'unknown' && toiletAccessibility === 'unknown') {
       return null;
     }
@@ -125,10 +127,13 @@ class WheelchairAndToiletAccessibility extends React.Component<Props> {
       isWheelmapFeature(feature) && includes(['yes', 'limited'], wheelchairAccessibility);
     const isToiletButtonShown = !hasBlacklistedCategory && canAddToiletStatus;
 
+    const findToiletsNearby = toiletAccessibility !== 'yes';
+
     return (
       <div className={this.props.className}>
         {this.renderWheelchairButton(wheelchairAccessibility)}
         {isToiletButtonShown && this.renderToiletButton(toiletAccessibility)}
+        {findToiletsNearby && (toiletsNearby ? toiletsNearby.length : ':(')}
       </div>
     );
   }

--- a/src/components/NodeToolbar/AccessibilitySection/WheelchairAndToiletAccessibility.js
+++ b/src/components/NodeToolbar/AccessibilitySection/WheelchairAndToiletAccessibility.js
@@ -289,6 +289,10 @@ const StyledBasicPlaceAccessibility = styled(WheelchairAndToiletAccessibility)`
     .right-arrow {
       padding: 0 10px;
     }
+
+    &:hover {
+      background-color: ${colors.linkBackgroundColorTransparent};
+    }
   }
 `;
 

--- a/src/components/NodeToolbar/AccessibilitySection/WheelchairAndToiletAccessibility.js
+++ b/src/components/NodeToolbar/AccessibilitySection/WheelchairAndToiletAccessibility.js
@@ -11,6 +11,7 @@ import {
   accessibilityDescription,
   toiletDescription,
   isWheelmapFeature,
+  normalizedCoordinatesForFeature,
 } from '../../../lib/Feature';
 import colors from '../../../lib/colors';
 import PenIcon from '../../icons/actions/PenIcon';
@@ -19,6 +20,8 @@ import { getCategoryIdFromProperties } from '../../../lib/Categories';
 import type { YesNoLimitedUnknown, YesNoUnknown } from '../../../lib/Feature';
 import ToiletStatusAccessibleIcon from '../../icons/accessibility/ToiletStatusAccessible';
 import ToiletStatusNotAccessibleIcon from '../../icons/accessibility/ToiletStatusNotAccessible';
+import { geoDistance } from '../../../lib/geoDistance';
+import { formatDistance } from '../../../lib/formatDistance';
 
 // Don't incentivize people to add toilet status to places of these categories
 const placeCategoriesWithoutExtraToiletEntry = [
@@ -68,6 +71,7 @@ type Props = {
   toiletsNearby: ?(Feature[]),
   onOpenWheelchairAccessibility: () => void,
   onOpenToiletAccessibility: () => void,
+  onOpenToiletNearby: (feature: Feature) => void,
   className: string,
   isEditingEnabled: boolean,
 };
@@ -107,8 +111,32 @@ class WheelchairAndToiletAccessibility extends React.Component<Props> {
     );
   }
 
+  renderNearbyToilets() {
+    const { feature, toiletsNearby, onOpenToiletNearby } = this.props;
+    if (!toiletsNearby) {
+      return;
+    }
+
+    const featureCoords = normalizedCoordinatesForFeature(feature);
+    // for now render only the closest toilet
+    return toiletsNearby.slice(0, 1).map((toiletFeature, i) => {
+      const toiletCoords = normalizedCoordinatesForFeature(toiletFeature);
+      const distance = geoDistance(featureCoords, toiletCoords);
+      const formattedDistance = formatDistance(distance);
+
+      return (
+        <button key={i} onClick={() => onOpenToiletNearby(toiletFeature)} className="toilet-nearby">
+          {formattedDistance.distance}
+          {formattedDistance.unit}
+          <b className="right-arrow">⇢</b>
+          <ToiletStatusAccessibleIcon />
+        </button>
+      );
+    });
+  }
+
   render() {
-    const { feature, toiletsNearby } = this.props;
+    const { feature } = this.props;
     const { properties } = feature || {};
     if (!properties) {
       return null;
@@ -116,7 +144,7 @@ class WheelchairAndToiletAccessibility extends React.Component<Props> {
 
     const wheelchairAccessibility = isWheelchairAccessible(properties);
     const toiletAccessibility = hasAccessibleToilet(properties);
-    console.log(toiletAccessibility, properties);
+
     if (wheelchairAccessibility === 'unknown' && toiletAccessibility === 'unknown') {
       return null;
     }
@@ -133,7 +161,7 @@ class WheelchairAndToiletAccessibility extends React.Component<Props> {
       <div className={this.props.className}>
         {this.renderWheelchairButton(wheelchairAccessibility)}
         {isToiletButtonShown && this.renderToiletButton(toiletAccessibility)}
-        {findToiletsNearby && (toiletsNearby ? toiletsNearby.length : ':(')}
+        {findToiletsNearby && this.renderNearbyToilets()}
       </div>
     );
   }
@@ -249,6 +277,15 @@ const StyledBasicPlaceAccessibility = styled(WheelchairAndToiletAccessibility)`
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+  }
+
+  .toilet-nearby {
+    display: flex;
+    align-items: center;
+
+    .right-arrow {
+      padding: 0 10px;
+    }
   }
 `;
 

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -52,6 +52,7 @@ type Props = {
   featureId: string | number,
   sources: SourceWithLicense[],
   photos: PhotoModel[],
+  toiletsNearby: ?(Feature[]),
   categories: CategoryLookupTables,
   category: ?Category,
   parentCategory: ?Category,

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -63,6 +63,7 @@ type Props = {
   onOpenReportMode: ?() => void,
   onOpenToiletAccessibility: () => void,
   onOpenWheelchairAccessibility: () => void,
+  onOpenToiletNearby: (feature: Feature) => void,
   onCloseWheelchairAccessibility: () => void,
   onCloseToiletAccessibility: () => void,
   onClickCurrentMarkerIcon?: (feature: Feature) => void,

--- a/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
+++ b/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
@@ -102,6 +102,8 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
         ...state,
         ...resolvedCategories,
         resolvedSources: resolvedPlaceDetails.sources,
+        resolvedPhotos: resolvedPlaceDetails.photos,
+        resolvedToiletsNearby: resolvedPlaceDetails.toiletsNearby,
         resolvedRequiredData: { resolvedFeature: feature, resolvedEquipmentInfo: equipmentInfo },
         lastFeatureId: props.featureId,
         lastEquipmentInfoId: props.equipmentInfoId,
@@ -124,6 +126,7 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
       requiredDataPromise: null,
       resolvedPhotos: null,
       resolvedSources: null,
+      resolvedToiletsNearby: null,
     };
   }
 
@@ -160,15 +163,17 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
         resolvedRequiredData: { resolvedFeature: feature, resolvedEquipmentInfo: equipmentInfo },
         resolvedSources: resolvedPlaceDetails.sources,
         resolvedPhotos: resolvedPlaceDetails.photos,
+        resolvedToiletsNearby: resolvedPlaceDetails.toiletsNearby,
         ...resolvedCategories,
       });
     } else {
-      const { feature, equipmentInfo, sources, photos } = this.props;
+      const { feature, equipmentInfo, sources, photos, toiletsNearby } = this.props;
 
       // they are always all promises, this is to make flow happy
       if (
         feature instanceof Promise &&
         (!equipmentInfo || equipmentInfo instanceof Promise) &&
+        (!toiletsNearby || toiletsNearby instanceof Promise) &&
         sources instanceof Promise &&
         photos instanceof Promise
       ) {
@@ -187,6 +192,7 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
           );
           photos.then(resolved => this.handlePhotosFetched(photos, resolved));
           sources.then(resolved => this.handleSourcesFetched(sources, resolved));
+          toiletsNearby.then(resolved => this.handleToiletsNearbyFetched(toiletsNearby, resolved));
         });
       } else {
         console.warn('received mixed promise / resolved results - this should never happen!');
@@ -220,6 +226,17 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
     this.setState({ resolvedPhotos });
   }
 
+  handleToiletsNearbyFetched(
+    toiletsNearbyPromise: Promise<Feature[]>,
+    resolvedToiletsNearby: Feature[]
+  ) {
+    // ignore unwanted promise results (e.g. after unmounting)
+    if (toiletsNearbyPromise !== this.props.toiletsNearby) {
+      return;
+    }
+    this.setState({ resolvedToiletsNearby });
+  }
+
   handleSourcesFetched(
     sourcesPromise: Promise<SourceWithLicense[]>,
     resolvedSources: SourceWithLicense[]
@@ -238,6 +255,7 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
       resolvedRequiredData,
       resolvedPhotos,
       resolvedSources,
+      resolvedToiletsNearby,
     } = this.state;
     // strip promises from props
     const {
@@ -246,6 +264,7 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
       equipmentInfo,
       lightweightFeature,
       photos,
+      toiletsNearby,
       ...remainingProps
     } = this.props;
 
@@ -263,6 +282,7 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
           equipmentInfo={resolvedEquipmentInfo}
           sources={resolvedSources || []}
           photos={resolvedPhotos || []}
+          toiletsNearby={resolvedToiletsNearby || []}
           ref={t => (this.nodeToolbar = t)}
         />
       );
@@ -276,6 +296,7 @@ class NodeToolbarFeatureLoader extends React.Component<Props, State> {
           parentCategory={parentCategory}
           feature={lightweightFeature}
           equipmentInfo={null}
+          toiletsNearby={null}
           sources={[]}
           photos={[]}
           ref={t => (this.nodeToolbar = t)}

--- a/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
+++ b/src/components/NodeToolbar/NodeToolbarFeatureLoader.js
@@ -34,6 +34,7 @@ type Props = {
   onOpenReportMode: ?() => void,
   onOpenToiletAccessibility: () => void,
   onOpenWheelchairAccessibility: () => void,
+  onOpenToiletNearby: (feature: Feature) => void,
   onCloseWheelchairAccessibility: () => void,
   onCloseToiletAccessibility: () => void,
   onClickCurrentMarkerIcon?: (feature: Feature) => void,

--- a/src/lib/Feature.js
+++ b/src/lib/Feature.js
@@ -543,6 +543,7 @@ export function removeNullAndUndefinedFields<T: {} | {}[]>(something: T): ?T {
   return something;
 }
 
+// returns coordinates in [lon, lat] array
 export function normalizedCoordinatesForFeature(feature: Feature): ?[number, number] {
   const geometry = feature ? feature.geometry : null;
   if (!(geometry instanceof Object)) return null;

--- a/src/lib/Feature.js
+++ b/src/lib/Feature.js
@@ -15,7 +15,7 @@ import useImperialUnits from './useImperialUnits';
 import type { EquipmentInfo } from './EquipmentInfo';
 import { isEquipmentAccessible } from './EquipmentInfo';
 import type { Category } from './Categories';
-import { categoryNameFor } from './Categories';
+import { categoryNameFor, getCategoryIdFromProperties } from './Categories';
 import type { LocalizedString } from './i18n';
 import { normalizeCoordinates } from './normalizeCoordinates';
 
@@ -326,7 +326,15 @@ export function accessibilityCloudFeatureCollectionFromResponse(response: any) {
 export function hasAccessibleToilet(
   properties: WheelmapProperties | AccessibilityCloudProperties
 ): YesNoUnknown {
-  if (!properties) return 'unknown';
+  if (!properties) {
+    return 'unknown';
+  }
+
+  const isToilet = getCategoryIdFromProperties(properties) === 'toilets';
+  if (isToilet) {
+    const isAccessible = isWheelchairAccessible(properties);
+    return isAccessible === 'yes' ? 'yes' : 'no';
+  }
 
   // wheelmap classic result
   if (properties && properties.wheelchair_toilet) {

--- a/src/lib/formatDistance.js
+++ b/src/lib/formatDistance.js
@@ -1,0 +1,64 @@
+// @flow
+
+import useImperialUnits from './useImperialUnits';
+
+const unitSets = {
+  metric: [
+    {
+      unit: 'm',
+      max: 995,
+      mult: 1,
+    },
+    {
+      unit: 'km',
+      mult: 1 / 1000,
+    },
+  ],
+  imperialFeet: [
+    {
+      unit: 'ft',
+      mult: 3.28084,
+      max: 5000,
+    },
+    {
+      unit: 'mi',
+      mult: 1 / 5280,
+    },
+  ],
+  imperialYard: [
+    {
+      unit: 'yd',
+      mult: 1.09361,
+      max: 995,
+    },
+    {
+      unit: 'mi',
+      mult: 1 / 1760,
+    },
+  ],
+};
+
+// transforms the distance into the closest fitting unit and displays with reduced precision
+//    5.31 becomes 5.3m
+//    254.1234 becomes 250m
+//    2123.12 becomes  2.1km
+//    12123.12 becomes  12km
+export function formatDistance(distanceInMeters: number, precision: number = 2) {
+  const unitSet = useImperialUnits() ? unitSets.imperialFeet : unitSets.metric;
+
+  let distance = distanceInMeters;
+  let unit = distanceInMeters;
+  // find the best matching unit to display
+  for (const step of unitSet) {
+    distance = distance * (step.mult || 1.0);
+    unit = step.unit;
+
+    if (!step.max || distance < step.max) {
+      break;
+    }
+  }
+
+  // format according to precision, parseFloat ensures no 5e+2 from toPrecision remains
+  distance = parseFloat(distance.toPrecision(precision)).toString();
+  return { unit, distance };
+}

--- a/src/lib/geoDistance.js
+++ b/src/lib/geoDistance.js
@@ -1,0 +1,37 @@
+// @flow
+
+function toRadians(degrees: number) {
+  return (degrees * Math.PI) / 180;
+}
+
+// From http://gis.stackexchange.com/a/20241
+function earthRadiusForLatitude(latitudeInDegrees: number, heightAboveSeaLevel: number = 0) {
+  if (isNaN(latitudeInDegrees) || latitudeInDegrees > 90 || latitudeInDegrees < -90) {
+    throw new Error('Incorrect latitude given.');
+  }
+  // x = latitude in radians
+  const x = toRadians(latitudeInDegrees);
+  const r1 = 6378137; // radius at the equator
+  const r2 = 6356752; // radius at the poles
+  const z = Math.sqrt(
+    (Math.pow(r1 * r1 * Math.cos(x), 2) + Math.pow(r2 * r2 * Math.sin(x), 2)) /
+      (Math.pow(r1 * Math.cos(x), 2) + Math.pow(r2 * Math.sin(x), 2))
+  );
+  return z + heightAboveSeaLevel;
+}
+
+type LonLatPair = [number, number];
+
+// Haversine formula, from http://www.movable-type.co.uk/scripts/latlong.html
+export function geoDistance([lon1, lat1]: LonLatPair, [lon2, lat2]: LonLatPair) {
+  const radius = earthRadiusForLatitude(lat1 + 0.5 * (lat2 - lat1));
+  const phi1 = toRadians(lat1);
+  const phi2 = toRadians(lat2);
+  const deltaPhi = toRadians(lat2 - lat1);
+  const deltaLambda = toRadians(lon2 - lon1);
+  const a =
+    Math.sin(deltaPhi / 2) * Math.sin(deltaPhi / 2) +
+    Math.cos(phi1) * Math.cos(phi2) * Math.sin(deltaLambda / 2) * Math.sin(deltaLambda / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return radius * c;
+}

--- a/src/lib/getToiletsNearby.js
+++ b/src/lib/getToiletsNearby.js
@@ -1,0 +1,127 @@
+// @flow
+import flatten from 'lodash/flatten';
+
+import config from './config';
+import env from './env';
+import type { Feature } from './Feature';
+
+import { globalFetchManager } from './FetchManager';
+import {
+  convertResponseToWheelmapFeature,
+  accessibilityCloudFeatureCollectionFromResponse,
+  hasAccessibleToilet,
+  normalizedCoordinatesForFeature,
+} from './Feature';
+import { buildSourceIdParams } from '../components/Map/getAccessibilityCloudTileUrl';
+
+function calculateBoundingBox(lat: number, lon: number, radius: number) {
+  const latRadian = (lat * Math.PI) / 180;
+  const degLatKm = 110.574235;
+  const degLongKm = 110.572833 * Math.cos(latRadian);
+  const deltaLat = radius / 1000.0 / degLatKm;
+  const deltaLong = radius / 1000.0 / degLongKm;
+
+  const topLat = lat + deltaLat;
+  const bottomLat = lat - deltaLat;
+  const leftLng = lon - deltaLong;
+  const rightLng = lon + deltaLong;
+
+  return {
+    west: leftLng,
+    east: rightLng,
+    north: topLat,
+    south: bottomLat,
+  };
+}
+
+function fetchWheelmapToiletPlaces(lat: number, lon: number, radius: number): Promise<Feature[]> {
+  const bbox = calculateBoundingBox(lat, lon, radius);
+  const url = `${config.wheelmapApiBaseUrl}/api/nodes?bbox=${bbox.west},${bbox.south},${
+    bbox.east
+  },${bbox.north}&per_page=50&wheelchair=yes&wheelchair_toilet=yes&api_key=${
+    config.wheelmapApiKey
+  }`;
+
+  return globalFetchManager
+    .fetch(url, { cordova: true })
+    .then(response => response.json())
+    .then(responseJson => responseJson.nodes.map(convertResponseToWheelmapFeature));
+}
+
+function fetchAcToiletPlaces(
+  lat: number,
+  lon: number,
+  radius: number,
+  includeSourceIds: Array<string>,
+  excludeSourceIds: Array<string>
+): Promise<Feature[]> {
+  const sourceIdParams = buildSourceIdParams(includeSourceIds, excludeSourceIds);
+  const url = `${
+    env.public.accessibilityCloud.baseUrl.cached
+  }/place-infos.json?${sourceIdParams}&latitude=${lat}&longitude=${lon}&accuracy=${radius}&appToken=${
+    env.public.accessibilityCloud.appToken
+  }`;
+  return globalFetchManager
+    .fetch(url, { cordova: true })
+    .then(response => response.json())
+    .then(responseJson => {
+      const parsed = accessibilityCloudFeatureCollectionFromResponse(responseJson);
+      return parsed ? parsed.features : [];
+    });
+}
+
+function filterAccessibleToilets(feature: Feature): boolean {
+  if (!feature || !feature.properties) {
+    return false;
+  }
+
+  const hasToilet = hasAccessibleToilet(feature.properties) === 'yes';
+  return hasToilet;
+}
+
+const nearbyRadiusMeters = 300;
+
+export function fetchToiletsNearby(
+  lat: number,
+  lon: number,
+  disableWheelmapSource: boolean,
+  includeSourceIds: Array<string>,
+  excludeSourceIds: Array<string>
+) {
+  const wm = disableWheelmapSource
+    ? Promise.resolve([])
+    : fetchWheelmapToiletPlaces(lat, lon, nearbyRadiusMeters);
+  const ac = fetchAcToiletPlaces(lat, lon, nearbyRadiusMeters, includeSourceIds, excludeSourceIds);
+
+  return Promise.all([wm, ac]).then(results => {
+    return flatten(results).filter(filterAccessibleToilets);
+  });
+}
+
+export function fetchToiletsNearFeature(
+  feature: Feature,
+  disableWheelmapSource: boolean,
+  includeSourceIds: Array<string>,
+  excludeSourceIds: Array<string>
+) {
+  if (!feature) {
+    return null;
+  }
+
+  if (feature.properties && hasAccessibleToilet(feature.properties) === 'yes') {
+    return null;
+  }
+
+  const coords = normalizedCoordinatesForFeature(feature);
+  if (!coords) {
+    return;
+  }
+
+  const [lon, lat] = coords;
+
+  return fetchToiletsNearby(lat, lon, disableWheelmapSource, includeSourceIds, excludeSourceIds);
+}
+
+if (typeof window !== 'undefined') {
+  window.fetchToiletsNearby = fetchToiletsNearby;
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -113,7 +113,7 @@ export default class App extends BaseApp {
       );
 
       if (ctx.query.routeName) {
-        const routePropsPromise = getInitialRouteProps(ctx.query, isServer);
+        const routePropsPromise = getInitialRouteProps(ctx.query, appPropsPromise, isServer);
         routeProps = await routePropsPromise;
       }
       appProps = await appPropsPromise;


### PR DESCRIPTION
- In place details data query:
 - Fetch places nearby (300m) using wheelmap & ac
   APIs 
 - Filter by accessible toilet & sort by distance
- Pass data through whole app
- In WheelchairAndToiletAccessibility render nearby 
  toilets
 - format distance in human readable format
 - when selecting link, open place details of
   place holding toilet