### PR TITLE
Track `appId` and `organizationId` on a11y editing

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="org.wheelmap.android.online" id="de.sozialhelden.wheelmap.iphone" version="4.32.0" 
+<widget android-packageName="org.wheelmap.android.online" id="de.sozialhelden.wheelmap.iphone" version="4.33.0" 
     xmlns="http://www.w3.org/ns/widgets" 
     xmlns:android="http://schemas.android.com/apk/res/android" 
     xmlns:cdv="http://cordova.apache.org/ns/1.0">

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="org.wheelmap.android.online" id="de.sozialhelden.wheelmap.iphone" version="4.30.0" 
+<widget android-packageName="org.wheelmap.android.online" id="de.sozialhelden.wheelmap.iphone" version="4.31.0" 
     xmlns="http://www.w3.org/ns/widgets" 
     xmlns:android="http://schemas.android.com/apk/res/android" 
     xmlns:cdv="http://cordova.apache.org/ns/1.0">

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="org.wheelmap.android.online" id="de.sozialhelden.wheelmap.iphone" version="4.31.0" 
+<widget android-packageName="org.wheelmap.android.online" id="de.sozialhelden.wheelmap.iphone" version="4.32.0" 
     xmlns="http://www.w3.org/ns/widgets" 
     xmlns:android="http://schemas.android.com/apk/res/android" 
     xmlns:cdv="http://cordova.apache.org/ns/1.0">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wheelmap-react",
-  "version": "4.31.0",
+  "version": "4.32.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wheelmap-react",
-  "version": "4.30.0",
+  "version": "4.31.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wheelmap-react",
-  "version": "4.32.0",
+  "version": "4.33.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wheelmap-react",
   "displayName": "Wheelmap",
-  "version": "4.32.0",
+  "version": "4.33.0",
   "homepage": "https://wheelmap.org/beta/",
   "main": "lib/App.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wheelmap-react",
   "displayName": "Wheelmap",
-  "version": "4.30.0",
+  "version": "4.31.0",
   "homepage": "https://wheelmap.org/beta/",
   "main": "lib/App.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wheelmap-react",
   "displayName": "Wheelmap",
-  "version": "4.31.0",
+  "version": "4.32.0",
   "homepage": "https://wheelmap.org/beta/",
   "main": "lib/App.js",
   "license": "MIT",

--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ import type { SearchResultFeature } from './lib/searchPlaces';
 import type { EquipmentInfo, EquipmentInfoProperties } from './lib/EquipmentInfo';
 import type { MappingEvents, MappingEvent } from './lib/MappingEvent';
 import { type Cluster } from './components/Map/Cluster';
+import { type AppModel } from './lib/App';
 
 import MainView, { UnstyledMainView } from './MainView';
 
@@ -75,7 +76,7 @@ type Props = {
   searchQuery?: ?string,
   searchResults?: SearchResultCollection | Promise<SearchResultCollection>,
   category?: string,
-  clientSideConfiguration: ClientSideConfiguration,
+  app: AppModel,
   lat: ?string,
   lon: ?string,
   zoom: ?string,
@@ -629,6 +630,7 @@ class App extends React.Component<Props, State> {
   getCurrentParams() {
     const params = {};
     const {
+      app,
       category,
       accessibilityFilter,
       toiletFilter,
@@ -637,7 +639,6 @@ class App extends React.Component<Props, State> {
       disableWheelmapSource,
       includeSourceIds,
       excludeSourceIds,
-      clientSideConfiguration,
       overriddenAppId,
       inEmbedMode,
     } = this.props;
@@ -665,21 +666,21 @@ class App extends React.Component<Props, State> {
     // ensure to keep widget/custom whitelabel parameters
     if (includeSourceIds && includeSourceIds.length > 0) {
       const includeSourceIdsAsString = includeSourceIds.join(',');
-      if (includeSourceIdsAsString !== clientSideConfiguration.includeSourceIds.join(',')) {
+      if (includeSourceIdsAsString !== app.clientSideConfiguration.includeSourceIds.join(',')) {
         params.includeSourceIds = includeSourceIdsAsString;
       }
     }
 
     if (excludeSourceIds && excludeSourceIds.length > 0) {
       const excludeSourceIdsAsString = excludeSourceIds.join(',');
-      if (excludeSourceIdsAsString !== clientSideConfiguration.excludeSourceIds.join(',')) {
+      if (excludeSourceIdsAsString !== app.clientSideConfiguration.excludeSourceIds.join(',')) {
         params.excludeSourceIds = excludeSourceIdsAsString;
       }
     }
 
     if (
       typeof disableWheelmapSource !== 'undefined' &&
-      disableWheelmapSource !== clientSideConfiguration.disableWheelmapSource
+      disableWheelmapSource !== app.clientSideConfiguration.disableWheelmapSource
     ) {
       params.disableWheelmapSource = disableWheelmapSource ? 'true' : 'false';
     }
@@ -909,7 +910,7 @@ class App extends React.Component<Props, State> {
       // feature list (e.g. cluster panel)
       activeCluster: this.state.activeCluster,
 
-      clientSideConfiguration: this.props.clientSideConfiguration,
+      app: this.props.app,
     };
 
     return (

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -6,6 +6,8 @@ import { type CategoryLookupTables } from './lib/Categories';
 // Only extend this with value that are sensible global values that potentially might be needed
 // everywhere
 export type AppContext = {
+  organizationId?: string,
+  appId?: string,
   baseUrl: string,
   categories: CategoryLookupTables,
 };

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -50,7 +50,7 @@ import { type PlaceDetailsProps } from './app/PlaceDetailsProps';
 import type { PhotoModel } from './lib/PhotoModel';
 
 import { hasAllowedAnalytics } from './lib/savedState';
-import { ClientSideConfiguration } from './lib/ClientSideConfiguration';
+import { type App } from './lib/App';
 import { enableAnalytics, disableAnalytics } from './lib/Analytics';
 import ContributionThanksDialog from './components/ContributionThanksDialog/ContributionThanksDialog';
 import { insertPlaceholdersToAddPlaceUrl } from './lib/insertPlaceholdersToAddPlaceUrl';
@@ -157,7 +157,7 @@ type Props = {
   onCloseClusterPanel: () => void,
   onSelectFeatureFromCluster: (feature: Feature | EquipmentInfo) => void,
 
-  clientSideConfiguration: ClientSideConfiguration,
+  app: App,
   mappingEventHandlers: {
     updateJoinedMappingEvent: (joinedMappingEventId: ?string) => void,
   },
@@ -254,6 +254,7 @@ class MainView extends React.Component<Props, State> {
         <NodeToolbarFeatureLoader
           featureId={this.props.featureId}
           equipmentInfoId={this.props.equipmentInfoId}
+          app={this.props.app}
           cluster={this.props.activeCluster}
           modalNodeState={this.props.modalNodeState}
           accessibilityPresetStatus={this.props.accessibilityPresetStatus}
@@ -284,7 +285,7 @@ class MainView extends React.Component<Props, State> {
           onEquipmentSelected={this.props.onEquipmentSelected}
           onShowPlaceDetails={this.props.onShowPlaceDetails}
           inEmbedMode={this.props.inEmbedMode}
-          clientSideConfiguration={this.props.clientSideConfiguration}
+          app={this.props.app}
         />
       </div>
     );
@@ -307,9 +308,9 @@ class MainView extends React.Component<Props, State> {
       mappingEventHandlers,
       joinedMappingEventId,
       onCloseMappingEventsToolbar,
-      clientSideConfiguration,
+      app,
     } = this.props;
-    const productName = clientSideConfiguration.textContent.product.name;
+    const productName = app.textContent.product.name;
     const translatedProductName = translatedStringFromObject(productName);
 
     const focusTrapActive = !this.isAnyDialogVisible();
@@ -386,8 +387,8 @@ class MainView extends React.Component<Props, State> {
   }
 
   analyticsAllowedChangedHandler = (value: boolean) => {
-    const { clientSideConfiguration } = this.props;
-    const { googleAnalytics } = clientSideConfiguration.meta;
+    const { app } = this.props;
+    const { googleAnalytics } = app.meta;
 
     this.setState({ analyticsAllowed: value });
 
@@ -404,10 +405,11 @@ class MainView extends React.Component<Props, State> {
     const {
       isOnboardingVisible,
       onCloseOnboarding,
-      clientSideConfiguration,
+      app,
       isMappingEventWelcomeDialogVisible,
     } = this.props;
     const { analyticsAllowed } = this.state;
+    const { clientSideConfiguration } = app;
     const { headerMarkdown } = clientSideConfiguration.textContent.onboarding;
     const { googleAnalytics } = clientSideConfiguration.meta;
     const { logoURL } = clientSideConfiguration;
@@ -431,18 +433,11 @@ class MainView extends React.Component<Props, State> {
   }
 
   renderMainMenu() {
-    const {
-      logoURL,
-      customMainMenuLinks,
-      addPlaceURL,
-      textContent,
-    } = this.props.clientSideConfiguration;
-
+    const { customMainMenuLinks } = this.props.app;
+    const { logoURL, addPlaceURL, textContent } = this.props.app.clientSideConfiguration;
     return (
       <MainMenu
-        productName={translatedStringFromObject(
-          this.props.clientSideConfiguration.textContent.product.name
-        )}
+        productName={translatedStringFromObject(textContent.product.name)}
         className="main-menu"
         uniqueSurveyId={this.state.uniqueSurveyId}
         isOpen={this.props.isMainMenuOpen}
@@ -553,12 +548,10 @@ class MainView extends React.Component<Props, State> {
   }
 
   renderContributionThanksDialog() {
-    const { clientSideConfiguration } = this.props;
+    const { app } = this.props;
 
     // find add place link
-    const link = find(clientSideConfiguration.customMainMenuLinks, link =>
-      includes(link.tags, 'add-place')
-    );
+    const link = find(app.customMainMenuLinks, link => includes(link.tags, 'add-place'));
     const url = link
       ? insertPlaceholdersToAddPlaceUrl(
           translatedStringFromObject(link.url),
@@ -631,9 +624,9 @@ class MainView extends React.Component<Props, State> {
 
   renderWheelmapHomeLink() {
     if (typeof window !== 'undefined') {
-      const { clientSideConfiguration } = this.props;
-      const appName = translatedStringFromObject(clientSideConfiguration.textContent.product.name);
-      const logoURL = clientSideConfiguration.logoURL;
+      const { app } = this.props;
+      const appName = translatedStringFromObject(app.textContent.product.name);
+      const logoURL = app.logoURL;
 
       const queryParams = queryString.parse(window.location.search);
       delete queryParams.embedded;

--- a/src/app/MapData.js
+++ b/src/app/MapData.js
@@ -9,7 +9,7 @@ type MapProps = {};
 
 const MapData: DataTableEntry<MapProps> = {
   getHead(props) {
-    return <title key="title">{getProductTitle(props.clientSideConfiguration)}</title>;
+    return <title key="title">{getProductTitle(props.app.clientSideConfiguration)}</title>;
   },
 };
 

--- a/src/app/MappingEventDetailData.js
+++ b/src/app/MappingEventDetailData.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import { type DataTableEntry, type AppProps } from './getInitialProps';
-import { type MappingEvent } from '../lib/cache/MappingEventsCache';
+import { type MappingEvent } from '../lib/MappingEvent';
 import { translatedStringFromObject } from '../lib/i18n';
 
 type MappingEventDetailDataProps = {
@@ -9,9 +9,9 @@ type MappingEventDetailDataProps = {
 };
 
 const MappingEventDetailData: DataTableEntry<MappingEventDetailDataProps> = {
-  getHead({ mappingEvent, clientSideConfiguration }) {
+  getHead({ mappingEvent, app }) {
     const translatedProductName = translatedStringFromObject(
-      clientSideConfiguration.textContent.product.name
+      app.clientSideConfiguration.textContent.product.name
     );
     const title = translatedProductName
       ? `${mappingEvent.name} - ${translatedProductName}`

--- a/src/app/PlaceDetailsData.js
+++ b/src/app/PlaceDetailsData.js
@@ -227,8 +227,8 @@ const PlaceDetailsData: DataTableEntry<PlaceDetailsProps> = {
   },
 
   getHead(props) {
-    const { feature, photos, clientSideConfiguration, categories, equipmentInfo } = props;
-    const { textContent, meta } = clientSideConfiguration;
+    const { feature, photos, app, categories, equipmentInfo } = props;
+    const { textContent, meta } = app.clientSideConfiguration;
 
     const renderTitle = (feature, photos) => {
       const extras = [];
@@ -299,7 +299,7 @@ const PlaceDetailsData: DataTableEntry<PlaceDetailsProps> = {
 
       extras.unshift(
         <meta content="place" property="og:type" key="og:type" />,
-        <title key="title">{getProductTitle(clientSideConfiguration, fullTitle)}</title>
+        <title key="title">{getProductTitle(app.clientSideConfiguration, fullTitle)}</title>
       );
 
       return <React.Fragment>{extras}</React.Fragment>;

--- a/src/app/SearchData.js
+++ b/src/app/SearchData.js
@@ -123,7 +123,7 @@ const SearchData: DataTableEntry<SearchProps> = {
   },
 
   getHead(props) {
-    const { clientSideConfiguration, searchQuery } = props;
+    const { app, searchQuery } = props;
     let searchTitle;
 
     if (searchQuery) {
@@ -131,7 +131,7 @@ const SearchData: DataTableEntry<SearchProps> = {
       searchTitle = t`Search results`;
     }
 
-    return <title key="title">{getProductTitle(clientSideConfiguration, searchTitle)}</title>;
+    return <title key="title">{getProductTitle(app.clientSideConfiguration, searchTitle)}</title>;
   },
 };
 

--- a/src/components/NodeToolbar/AccessibilityEditor/ToiletStatusEditor.js
+++ b/src/components/NodeToolbar/AccessibilityEditor/ToiletStatusEditor.js
@@ -12,6 +12,7 @@ import RadioStatusEditor from './RadioStatusEditor';
 import ToiletStatusAccessibleIcon from '../../icons/accessibility/ToiletStatusAccessible';
 import ToiletStatusNotAccessibleIcon from '../../icons/accessibility/ToiletStatusNotAccessible';
 import { type CategoryLookupTables } from '../../../lib/Categories';
+import { AppContextConsumer } from '../../../AppContext';
 
 type SaveOptions = {
   featureId: string,
@@ -60,17 +61,21 @@ export default function ToiletStatusEditor(props: Props) {
   };
 
   return (
-    <RadioStatusEditor
-      {...props}
-      undefinedStringValue="unknown"
-      getValueFromFeature={feature => feature.properties.wheelchair_toilet}
-      saveValue={value => saveToiletStatus({ ...props, value })}
-      renderChildrenForValue={({ value, categoryId }) => icons[value]}
-      shownStatusOptions={['yes', 'no']}
-      captionForValue={value => captions[value]}
-      descriptionForValue={value => descriptions[value]}
-    >
-      <header id="wheelchair-accessibility-header">{headerText}</header>
-    </RadioStatusEditor>
+    <AppContextConsumer>
+      {appContext => (
+        <RadioStatusEditor
+          {...props}
+          undefinedStringValue="unknown"
+          getValueFromFeature={feature => feature.properties.wheelchair_toilet}
+          saveValue={value => saveToiletStatus({ ...props, appContext, value })}
+          renderChildrenForValue={({ value, categoryId }) => icons[value]}
+          shownStatusOptions={['yes', 'no']}
+          captionForValue={value => captions[value]}
+          descriptionForValue={value => descriptions[value]}
+        >
+          <header id="wheelchair-accessibility-header">{headerText}</header>
+        </RadioStatusEditor>
+      )}
+    </AppContextConsumer>
   );
 }

--- a/src/components/NodeToolbar/AccessibilityEditor/WheelchairStatusEditor.js
+++ b/src/components/NodeToolbar/AccessibilityEditor/WheelchairStatusEditor.js
@@ -9,6 +9,7 @@ import { saveWheelchairStatus } from './saveStatus';
 import RadioStatusEditor from './RadioStatusEditor';
 import Icon from '../../Icon';
 import { type CategoryLookupTables } from '../../../lib/Categories';
+import { AppContextConsumer } from '../../../AppContext';
 
 type SaveOptions = {
   featureId: string,
@@ -25,26 +26,30 @@ type Props = SaveOptions & {
 
 export default function WheelchairStatusEditor(props: Props) {
   return (
-    <RadioStatusEditor
-      {...props}
-      undefinedStringValue="unknown"
-      getValueFromFeature={feature => feature.properties.wheelchair}
-      saveValue={value => saveWheelchairStatus({ ...props, value })}
-      renderChildrenForValue={({ value, categoryId }) => (
-        <Icon
-          accessibility={value}
-          category={categoryId}
-          size="medium"
-          withArrow
-          shadowed
-          centered
-        />
+    <AppContextConsumer>
+      {appContext => (
+        <RadioStatusEditor
+          {...props}
+          undefinedStringValue="unknown"
+          getValueFromFeature={feature => feature.properties.wheelchair}
+          saveValue={value => saveWheelchairStatus({ ...props, appContext, value })}
+          renderChildrenForValue={({ value, categoryId }) => (
+            <Icon
+              accessibility={value}
+              category={categoryId}
+              size="medium"
+              withArrow
+              shadowed
+              centered
+            />
+          )}
+          shownStatusOptions={['yes', 'limited', 'no']}
+          captionForValue={value => shortAccessibilityName(value)}
+          descriptionForValue={value => accessibilityDescription(value)}
+        >
+          <header id="wheelchair-accessibility-header">{t`How wheelchair accessible is this place?`}</header>
+        </RadioStatusEditor>
       )}
-      shownStatusOptions={['yes', 'limited', 'no']}
-      captionForValue={value => shortAccessibilityName(value)}
-      descriptionForValue={value => accessibilityDescription(value)}
-    >
-      <header id="wheelchair-accessibility-header">{t`How wheelchair accessible is this place?`}</header>
-    </RadioStatusEditor>
+    </AppContextConsumer>
   );
 }

--- a/src/components/NodeToolbar/AccessibilityEditor/saveStatus.js
+++ b/src/components/NodeToolbar/AccessibilityEditor/saveStatus.js
@@ -12,6 +12,7 @@ import type { WheelmapFeature, YesNoLimitedUnknown, YesNoUnknown } from '../../.
 import { trackEvent } from '../../../lib/Analytics';
 import Categories from '../../../lib/Categories';
 import { type CategoryLookupTables } from '../../../lib/Categories';
+import { type AppContext } from '../../../AppContext';
 
 type ExternalSaveOptions<T> = {
   featureId: string,
@@ -20,8 +21,7 @@ type ExternalSaveOptions<T> = {
   value: T,
   onSave: ?(value: T) => void,
   onClose: () => void,
-  appId: string,
-  organizationId: string,
+  appContext: AppContext,
 };
 
 type SaveOptions<T> = ExternalSaveOptions<T> & {
@@ -31,7 +31,7 @@ type SaveOptions<T> = ExternalSaveOptions<T> & {
 };
 
 function trackAttributeChanged<T>(options: SaveOptions<T>) {
-  const { value, categories, feature, featureId, propertyName } = options;
+  const { value, categories, feature, featureId, propertyName, appContext } = options;
 
   const { category, parentCategory } = Categories.getCategoriesForFeature(categories, feature);
   trackingEventBackend.track({
@@ -41,6 +41,8 @@ function trackAttributeChanged<T>(options: SaveOptions<T>) {
     placeInfoId: featureId,
     attributePath: `properties.${propertyName}`,
     previousValue: get(feature, `properties.${propertyName}`),
+    organizationId: appContext.organizationId,
+    appId: appContext.appId,
     newValue: value,
   });
 }
@@ -50,7 +52,6 @@ function save<T>(options: SaveOptions<T>): Promise<Response> {
 
   const formData = new FormData();
   formData.append(options.jsonPropertyName, String(value));
-
   const body = isCordova() ? { [options.jsonPropertyName]: value } : formData;
 
   const requestOptions = {
@@ -71,6 +72,7 @@ function save<T>(options: SaveOptions<T>): Promise<Response> {
       throw response;
     })
     .then(json => {
+      debugger;
       trackEvent({
         category: 'UpdateAccessibilityData',
         action: propertyName,

--- a/src/lib/App.js
+++ b/src/lib/App.js
@@ -1,0 +1,8 @@
+import { ClientSideConfiguration } from './ClientSideConfiguration';
+
+export type App = {
+  _id: string,
+  organizationId: string,
+  name: string,
+  clientSideConfiguration?: ClientSideConfiguration,
+};

--- a/src/lib/MappingEvent.js
+++ b/src/lib/MappingEvent.js
@@ -16,6 +16,7 @@ interface MappingEventStatistics {
 export interface MappingEvent {
   _id: string;
   organizationId: string;
+  appId?: string;
   sourceId?: string;
   name: string;
   description?: string;

--- a/src/lib/TrackingEventBackend.js
+++ b/src/lib/TrackingEventBackend.js
@@ -42,9 +42,9 @@ export default class TrackingEventBackend {
 
     const body = JSON.stringify({
       ...event,
-      organizationId,
-      appId,
-      mappingEvent: mappingEvent && pick(mappingEvent, '_id', 'name'),
+      mappingEvent:
+        mappingEvent &&
+        pick(mappingEvent, '_id', 'name', 'organizationId', 'appId', 'startTime', 'endTime'),
       userUUID,
       timestamp: Math.round(Date.now() / 1000),
       userAgent: getUserAgent(),

--- a/src/lib/cache/AppCache.js
+++ b/src/lib/cache/AppCache.js
@@ -6,36 +6,28 @@ import get from 'lodash/get';
 import URLDataCache from './URLDataCache';
 import env from '../env';
 import { type ClientSideConfiguration } from '../ClientSideConfiguration';
+import { type App } from '../App';
 
-type ClientSideConfigurationData = {
-  clientSideConfiguration: ClientSideConfiguration,
-};
-
-export default class ClientSideConfigurationCache extends URLDataCache<
-  ClientSideConfigurationData
-> {
-  getClientSideConfiguration(hostName: string): Promise<ClientSideConfiguration> {
+export default class AppCache extends URLDataCache<App> {
+  getApp(hostName: string): Promise<ClientSideConfiguration> {
     const url = this.getUrl(hostName);
 
     return this.getData(url).then(app => {
       const customMainMenuLinks = values(get(app, 'related.appLinks') || {});
 
       return {
-        ...app.clientSideConfiguration,
+        ...app,
         customMainMenuLinks,
       };
     });
   }
 
-  injectClientSideConfiguration(
-    hostName: string,
-    clientSideConfiguration: ClientSideConfiguration
-  ) {
+  injectApp(hostName: string, app: App) {
     const url = this.getUrl(hostName);
-    const { customMainMenuLinks, ...clientSideConfigurationWithoutLinks } = clientSideConfiguration;
+    const { customMainMenuLinks, ...appWithoutLinks } = app;
 
     this.inject(url, {
-      clientSideConfiguration: clientSideConfigurationWithoutLinks,
+      ...appWithoutLinks,
       related: {
         appLinks: keyBy(customMainMenuLinks, '_id'),
       },
@@ -51,6 +43,6 @@ export default class ClientSideConfigurationCache extends URLDataCache<
   }
 }
 
-export const clientSideConfigurationCache = new ClientSideConfigurationCache({
+export const appCache = new AppCache({
   ttl: 1000 * 60 * 5,
 });

--- a/src/lib/cache/MappingEventsCache.js
+++ b/src/lib/cache/MappingEventsCache.js
@@ -25,7 +25,7 @@ export default class MappingEventsCache extends URLDataCache<MappingEventsData> 
     }));
   }
 
-  async getMappingEvent(_id: string): Promise<MappingEvent | undefined> {
+  async getMappingEvent(_id: string): Promise<MappingEvent | typeof undefined> {
     const mappingEvents = await this.getMappingEvents();
     return mappingEvents.find(mappingEvent => mappingEvent._id === _id);
   }

--- a/src/lib/savedState.js
+++ b/src/lib/savedState.js
@@ -7,13 +7,9 @@ import uuidv4 from 'uuid/v4';
 const lastMoveDateString = storage.getItem('wheelmap.map.lastMoveDate');
 
 const initialPropsCategoryDataString = storage.getItem('wheelmap.initialProps.rawCategoryLists');
-const initialPropsClientSideConfigurationString = storage.getItem(
-  'wheelmap.initialProps.clientSideConfiguration'
-);
+const initialPropsAppString = storage.getItem('wheelmap.initialProps.app');
 
-const hasInitialProps = !!(
-  initialPropsCategoryDataString && initialPropsClientSideConfigurationString
-);
+const hasInitialProps = !!(initialPropsCategoryDataString && initialPropsAppString);
 
 const savedState = {
   map: {
@@ -28,7 +24,7 @@ const savedState = {
   initialProps: hasInitialProps
     ? {
         rawCategoryLists: JSON.parse(initialPropsCategoryDataString),
-        clientSideConfiguration: JSON.parse(initialPropsClientSideConfigurationString),
+        app: JSON.parse(initialPropsAppString),
       }
     : null,
 };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -214,8 +214,8 @@ export default class App extends BaseApp {
       isFirstTimeClientRender = false;
 
       // setup analytics for any client that has a google analytics tracking id
-      if (receivedProps.clientSideConfiguration) {
-        const { googleAnalytics } = receivedProps.clientSideConfiguration.meta;
+      if (receivedProps.app) {
+        const { googleAnalytics } = receivedProps.app.clientSideConfiguration.meta;
         if (googleAnalytics && googleAnalytics.trackingId) {
           restoreAnalytics(googleAnalytics.trackingId);
           trackPageView(path);
@@ -264,7 +264,7 @@ export default class App extends BaseApp {
       storeInitialRouteProps(routeName, appProps);
     }
 
-    const { textContent, meta } = this.props.clientSideConfiguration;
+    const { textContent, meta } = this.props.app.clientSideConfiguration;
     const { name: productName, description } = textContent.product;
     const { twitter, googleAnalytics, facebook } = meta;
 
@@ -297,6 +297,8 @@ export default class App extends BaseApp {
     const availableLocales: Locale[] = Object.keys(allTranslations).map(localeFromString);
 
     const appContext = {
+      appId: this.props.app._id,
+      organizationId: this.props.app.organizationId,
       baseUrl,
       categories: appProps.categories,
     };

--- a/src/pages/cordova-main.js
+++ b/src/pages/cordova-main.js
@@ -138,15 +138,15 @@ class CordovaMain extends React.PureComponent<Props, State> {
     }
     console.log('Received new initial props from server.', reloadedInitialProps);
     // strip translations, no need to cache them
-    const { rawCategoryLists, clientSideConfiguration } = reloadedInitialProps;
+    const { rawCategoryLists, app } = reloadedInitialProps;
 
-    storeInitialAppProps({ rawCategoryLists, clientSideConfiguration }, isBuilding);
+    storeInitialAppProps({ rawCategoryLists, app }, isBuilding);
     this.setState({
-      storedInitialProps: { rawCategoryLists, clientSideConfiguration },
+      storedInitialProps: { rawCategoryLists, app },
     });
     saveState({
       'initialProps.rawCategoryLists': JSON.stringify(rawCategoryLists),
-      'initialProps.clientSideConfiguration': JSON.stringify(clientSideConfiguration),
+      'initialProps.app': JSON.stringify(app),
     });
   };
 


### PR DESCRIPTION
- Extends the app context by an `app` attribute that contains the whole app’s configuration JSON
- Don’t cache `clientSideConfiguration` anymore, but its parent `App` object
- Make `app` property available over `AppContextConsumer`