### PR TITLE
Fix and Update Mapping Event Image OG Metadata

### DIFF
--- a/src/components/FacebookMeta.js
+++ b/src/components/FacebookMeta.js
@@ -5,18 +5,25 @@ import Head from 'next/head';
 import { type FacebookConfiguration } from '../lib/ClientSideConfiguration';
 
 type Props = {
-  facebook: FacebookConfiguration,
+  facebook: FacebookConfiguration & {
+    imageWidth: number,
+    imageHeight: number,
+  },
 };
 
 class FacebookMeta extends PureComponent<Props> {
   render() {
-    const { appId, admins, imageURL } = this.props.facebook;
+    const { appId, admins, imageURL, imageWidth, imageHeight } = this.props.facebook;
 
     return (
       <Head>
         {appId && <meta content={appId} property="fb:app_id" key="fb:app_id" />}
         {admins && <meta content={admins} property="fb:admins" key="fb:admins" />}
         {imageURL && <meta content={imageURL} property="og:image" key="og:image" />}
+        {imageURL && <meta content={imageWidth} property="og:image:width" key="og:image:width" />}
+        {imageURL && (
+          <meta content={imageHeight} property="og:image:height" key="og:image:height" />
+        )}
       </Head>
     );
   }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -44,6 +44,7 @@ import Categories from '../lib/Categories';
 
 import allTranslations from '../lib/translations.json';
 import { restoreAnalytics, trackPageView } from '../lib/Analytics';
+import { buildFullImageUrl } from '../lib/Image';
 
 let isServer = false;
 // only used in serverSideRendering when getting the initial props
@@ -286,10 +287,21 @@ export default class App extends BaseApp {
           ? `${mappingEvent.name} - ${translatedProductName}`
           : mappingEvent.name;
         translatedDescription = mappingEvent.description || mappingEvent.name;
+
+        const mappingEventImage = mappingEvent.images && mappingEvent.images[0];
+        const mappingEventImageUrl = mappingEventImage && buildFullImageUrl(mappingEventImage);
+
         facebookMetaData.imageURL =
-          mappingEvent.photoUrl || `${baseUrl}/static/images/eventPlaceholder.png`;
+          mappingEventImageUrl || `${baseUrl}/static/images/eventPlaceholder.png`;
+
+        // 2048x1288 is the dimension of the placeholder image
+        facebookMetaData.imageWidth = mappingEventImage ? mappingEventImage.dimensions.width : 2048;
+        facebookMetaData.imageHeight = mappingEventImage
+          ? mappingEventImage.dimensions.height
+          : 1288;
+
         twitterMetaData.imageUrl =
-          mappingEvent.photoUrl || `${baseUrl}/static/images/eventPlaceholder.png`;
+          mappingEventImageUrl || `${baseUrl}/static/images/eventPlaceholder.png`;
         ogUrl = `${baseUrl}/events/${mappingEvent._id}`;
       }
     }


### PR DESCRIPTION
This fixes the wrong image URL property used in creating OG metadata for mapping event images.
Also we supply `og:image:width` and `og:image:height` now.