### PR TITLE
Search Input Field Usable with International Character Input Methods

### DIFF
--- a/src/components/SearchToolbar/SearchInputField.js
+++ b/src/components/SearchToolbar/SearchInputField.js
@@ -21,8 +21,23 @@ type Props = {
   ariaRole: string,
 };
 
-class SearchInputField extends React.Component<Props> {
+type State = {
+  value: ?string,
+};
+
+class SearchInputField extends React.Component<Props, State> {
   input: ?HTMLInputElement;
+
+  state = {
+    value: null,
+  };
+
+  getDerivedStateFromProps(nextProps) {
+    const value = nextProps.placeholder || nextProps.searchQuery || '';
+    return {
+      value,
+    };
+  }
 
   focus() {
     if (!this.input) return;
@@ -43,7 +58,6 @@ class SearchInputField extends React.Component<Props> {
 
   render() {
     const {
-      searchQuery,
       onChange,
       disabled,
       hidden,
@@ -51,12 +65,12 @@ class SearchInputField extends React.Component<Props> {
       onBlur,
       onClick,
       className,
-      placeholder,
       ariaRole,
     } = this.props;
     // translator: Placeholder for search input field
     const defaultPlaceholder = t`Search for place or address`;
-    const value = placeholder || searchQuery || '';
+
+    const { value } = this.state;
 
     return (
       <input


### PR DESCRIPTION
There was a simple issue with the way it was implemented before.

The `SearchInputField` would get its value from outside as a prop. But without actually storing the value inside it's own state it is not a properly controlled component in React. 

This had several bugs as a consquence. Editing the search text with the cursor being somewhere in the middle made the cursor jump right to the end after a change.

Also system controls for chinese input methods for example would only show up for a split second and disappear immediately.

Now we use `getDerivedStateFromProps` so we can still get the value as a prop from outside as a single point of truth, but then immediately reflect that value into the `SearchInputField` state. This does the trick.