### PR TITLE
Different Panning/Zooming Input Methods in Embed Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "is-url": "^1.2.4",
     "isomorphic-unfetch": "^2.1.1",
     "leaflet": "^1.0.3",
+    "leaflet-gesture-handling": "sozialhelden/Leaflet.GestureHandling",
     "leaflet-tilelayer-geojson": "^1.0.4",
     "leaflet.markercluster": "^1.0.4",
     "local-storage-fallback": "^4.1.1",

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -587,6 +587,7 @@ class MainView extends React.Component<Props, State> {
       featureId,
       equipmentInfoId,
       isNodeToolbarDisplayed: isNodeToolbarVisible,
+      inEmbedMode,
     } = this.props;
     return (
       <DynamicMap
@@ -624,6 +625,7 @@ class MainView extends React.Component<Props, State> {
         hideHints={
           this.state.isOnSmallViewport && (isNodeToolbarVisible || this.props.isMainMenuOpen)
         }
+        inEmbedMode={inEmbedMode}
         {...config}
       />
     );

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -1,6 +1,8 @@
 // @flow
 
 import L from 'leaflet';
+import { GestureHandling } from 'leaflet-gesture-handling';
+import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css';
 import 'leaflet.markercluster/dist/leaflet.markercluster-src';
 import { t } from 'ttag';
 import includes from 'lodash/includes';
@@ -56,6 +58,8 @@ import './Leaflet.css';
 import './Map.css';
 import MappingEventHaloMarkerIcon from './MappingEventHaloMarkerIcon';
 import { hrefForMappingEvent } from '../../lib/MappingEvent';
+
+L.Map.addInitHook('addHandler', 'gestureHandling', GestureHandling);
 
 window.L = L;
 
@@ -124,6 +128,7 @@ type Props = {
   hideHints?: boolean,
   onLocationError: (error: any) => void,
   forwardedRef: ?(map: ?Map) => void,
+  inEmbedMode: boolean,
 };
 
 type State = {
@@ -295,6 +300,7 @@ export default class Map extends React.Component<Props, State> {
       zoom: initialMapState.zoom,
       minZoom: 2,
       zoomControl: false,
+      gestureHandling: this.props.inEmbedMode,
     });
 
     if (!map) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8977,7 +8977,7 @@ lcid@^2.0.0:
 
 leaflet-gesture-handling@sozialhelden/Leaflet.GestureHandling:
   version "1.1.8"
-  resolved "https://codeload.github.com/sozialhelden/Leaflet.GestureHandling/tar.gz/471ea9ca1db636a7e0ca7138615b12e5705037c6"
+  resolved "https://codeload.github.com/sozialhelden/Leaflet.GestureHandling/tar.gz/2960dc02100c97443fc89694500edd2c29d95495"
 
 leaflet-tilelayer-geojson@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8975,6 +8975,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+leaflet-gesture-handling@sozialhelden/Leaflet.GestureHandling:
+  version "1.1.8"
+  resolved "https://codeload.github.com/sozialhelden/Leaflet.GestureHandling/tar.gz/471ea9ca1db636a7e0ca7138615b12e5705037c6"
+
 leaflet-tilelayer-geojson@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/leaflet-tilelayer-geojson/-/leaflet-tilelayer-geojson-1.0.4.tgz#b115e8f889bbbdb8ddc272471dbbba8ffd4fb51b"


### PR DESCRIPTION
I found a Plugin for Leaflet which mimics the Google Maps behavior regarding panning and zooming for special cases like touch devices or for embedded map widgets.

A few notes:

* This is directly tied to the `embedded` query parameter. When it is true the mode switches.
* This is not only working on touch but is also useful for embedded widgets when visited on desktop. The text reflects this accordingly. You can see the examples on the [plugin website](https://www.npmjs.com/package/leaflet-gesture-handling): 
* The translations for the overlay text are already packaged with the plugin but there was exactly one instance where the translation for the macOS case was broken, and this was german. So I went ahead and [forked the repo](https://github.com/sozialhelden/Leaflet.GestureHandling) to get to a quick solution.
* While at it (=forking), I also made it so that the text appears center-aligned cause it looks nicer.

I reckon that while this is a good enough solution for now, the project does not seem to be well supported and we might run into other bugs in the future and would have to maintain our fork.
But maybe all this does not matter if we ditch Leaflet in the future anyway.

