### PR TITLE
Clean up of AppContext and App Types

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ import type { SearchResultFeature } from './lib/searchPlaces';
 import type { EquipmentInfo, EquipmentInfoProperties } from './lib/EquipmentInfo';
 import type { MappingEvents, MappingEvent } from './lib/MappingEvent';
 import { type Cluster } from './components/Map/Cluster';
-import { type AppModel } from './lib/App';
+import { type App as AppModel } from './lib/App';
 
 import MainView, { UnstyledMainView } from './MainView';
 

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -1,14 +1,12 @@
 // @flow
 
-import { createContext, type Context } from 'react';
+import { createContext } from 'react';
 import { type CategoryLookupTables } from './lib/Categories';
-import { App } from './lib/App';
+import { type App } from './lib/App';
 
-// Only extend this with value that are sensible global values that potentially might be needed
+// Only extend this with values that are sensible global values that potentially might be needed
 // everywhere
 export type AppContext = {
-  organizationId?: string,
-  appId?: string,
   app?: App,
   baseUrl: string,
   categories: CategoryLookupTables,

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -257,7 +257,6 @@ class MainView extends React.Component<Props, State> {
         <NodeToolbarFeatureLoader
           featureId={this.props.featureId}
           equipmentInfoId={this.props.equipmentInfoId}
-          app={this.props.app}
           cluster={this.props.activeCluster}
           modalNodeState={this.props.modalNodeState}
           accessibilityPresetStatus={this.props.accessibilityPresetStatus}
@@ -288,7 +287,6 @@ class MainView extends React.Component<Props, State> {
           onEquipmentSelected={this.props.onEquipmentSelected}
           onShowPlaceDetails={this.props.onShowPlaceDetails}
           inEmbedMode={this.props.inEmbedMode}
-          app={this.props.app}
         />
       </div>
     );
@@ -314,6 +312,7 @@ class MainView extends React.Component<Props, State> {
       onCloseMappingEventsToolbar,
       app,
     } = this.props;
+
     const productName = app.clientSideConfiguration.textContent.product.name;
     const translatedProductName = translatedStringFromObject(productName);
 
@@ -392,8 +391,7 @@ class MainView extends React.Component<Props, State> {
   }
 
   analyticsAllowedChangedHandler = (value: boolean) => {
-    const { app } = this.props;
-    const { googleAnalytics } = app.clientSideConfiguration.meta;
+    const googleAnalytics = this.props.app.clientSideConfiguration.meta.googleAnalytics;
 
     this.setState({ analyticsAllowed: value });
 
@@ -438,8 +436,13 @@ class MainView extends React.Component<Props, State> {
   }
 
   renderMainMenu() {
-    const { customMainMenuLinks } = this.props.app;
-    const { logoURL, addPlaceURL, textContent } = this.props.app.clientSideConfiguration;
+    const {
+      customMainMenuLinks,
+      logoURL,
+      addPlaceURL,
+      textContent,
+    } = this.props.app.clientSideConfiguration;
+
     return (
       <MainMenu
         productName={translatedStringFromObject(textContent.product.name)}
@@ -553,10 +556,10 @@ class MainView extends React.Component<Props, State> {
   }
 
   renderContributionThanksDialog() {
-    const { app } = this.props;
+    const { customMainMenuLinks } = this.props.app.clientSideConfiguration;
 
     // find add place link
-    const link = find(app.customMainMenuLinks, link => includes(link.tags, 'add-place'));
+    const link = find(customMainMenuLinks, link => includes(link.tags, 'add-place'));
 
     return (
       <AppContextConsumer>
@@ -640,8 +643,7 @@ class MainView extends React.Component<Props, State> {
 
   renderWheelmapHomeLink() {
     if (typeof window !== 'undefined') {
-      const { app } = this.props;
-      const { clientSideConfiguration } = app;
+      const { clientSideConfiguration } = this.props.app;
       const appName = translatedStringFromObject(clientSideConfiguration.textContent.product.name);
       const { logoURL } = clientSideConfiguration;
 

--- a/src/components/MappingEvents/MappingEventsToolbar.js
+++ b/src/components/MappingEvents/MappingEventsToolbar.js
@@ -32,6 +32,7 @@ const MappingEventsToolbar = ({
   const eventsText = t`Events`;
   // translator: Tagline describing the purpose of mapping events
   const mappingEventsTagLine = t`Meet the community and map the accessibility of places around you!`;
+
   const listedMappingEvents = mappingEvents
     .filter(event => event.status === 'ongoing' || event.status === 'planned')
     .filter(event => event.organizationId === app.organizationId);

--- a/src/lib/App.js
+++ b/src/lib/App.js
@@ -1,9 +1,11 @@
+// @flow
+
 import { ClientSideConfiguration } from './ClientSideConfiguration';
 
 export type App = {
   _id: string,
   organizationId: string,
   name: string,
-  clientSideConfiguration?: ClientSideConfiguration,
+  clientSideConfiguration: ClientSideConfiguration,
   tokenString: string,
 };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -16,7 +16,7 @@ import TwitterMeta from '../components/TwitterMeta';
 import FacebookMeta from '../components/FacebookMeta';
 import OpenGraph from '../components/OpenGraph';
 import NotFound from '../components/NotFound/NotFound';
-import { AppContextProvider } from '../AppContext';
+import { AppContextProvider, type AppContext } from '../AppContext';
 
 import {
   parseAcceptLanguageString,
@@ -308,10 +308,8 @@ export default class App extends BaseApp {
 
     const availableLocales: Locale[] = Object.keys(allTranslations).map(localeFromString);
 
-    const appContext = {
+    const appContext: AppContext = {
       app: this.props.app,
-      appId: this.props.app._id,
-      organizationId: this.props.app.organizationId,
       baseUrl,
       categories: appProps.categories,
     };


### PR DESCRIPTION
Die `clientSideConfiguration` ist client-seitig jetzt nicht mehr optional, wenn die API response verarbeitet wurde und diese nicht existiert failen wir early (wie bisher auch).
Das hat den Code letztendlich einfacher gemacht.

Außerdem wie ich auch auf Slack geschrieben habe:

Ich habe in meinem aktuellen Branch ein paar Inkonsistenzen und potentielle Bugs gefunden wegen dem `AppContext` und `App` Type.  Habe ein bisschen aufgeräumt und gefixed, so dass jetzt `AppContext` so aussieht:

```
export type AppContext = {
  app?: App,
  baseUrl: string,
  categories: CategoryLookupTables,
};
```
und `App` so:

```
export type App = {
  _id: string,
  organizationId: string,
  name: string,
  clientSideConfiguration: ClientSideConfiguration,
  tokenString: string,
};
```
Außerdem wurden die `customMainMenuLinks` immer top level mitgeliefert. Diese sind jetzt konsistent unter `clientSideConfiguration` zu finden