### PR TITLE
Tracking Events for Opening App and Joining/Leaving Events

### DIFF
--- a/src/components/ContributionThanksDialog/ContributionThanksDialog.js
+++ b/src/components/ContributionThanksDialog/ContributionThanksDialog.js
@@ -80,7 +80,7 @@ export default class ContributionThanksDialog extends React.Component<Props> {
     if (typeof window !== 'undefined') {
       const queryParams = queryString.parse(window.location.search);
       if (queryParams.uniqueSurveyId) {
-        trackingEventBackend.track(this.props.appContext, {
+        trackingEventBackend.track(this.props.appContext.app, {
           type: 'SurveyCompleted',
           uniqueSurveyId: queryParams.uniqueSurveyId,
         });

--- a/src/components/NodeToolbar/AccessibilityEditor/saveStatus.js
+++ b/src/components/NodeToolbar/AccessibilityEditor/saveStatus.js
@@ -34,7 +34,7 @@ function trackAttributeChanged<T>(options: SaveOptions<T>) {
   const { value, categories, feature, featureId, propertyName, appContext } = options;
 
   const { category, parentCategory } = Categories.getCategoriesForFeature(categories, feature);
-  trackingEventBackend.track(appContext, {
+  trackingEventBackend.track(appContext.app, {
     type: 'AttributeChanged',
     category: category ? category._id : 'unknown',
     parentCategory: parentCategory ? parentCategory._id : undefined,

--- a/src/lib/TrackingEventBackend.js
+++ b/src/lib/TrackingEventBackend.js
@@ -40,6 +40,7 @@ export type MappingEventJoinedTrackingEvent = {
 
 export type MappingEventLeftTrackingEvent = {
   type: 'MappingEventLeft',
+  leftMappingEventId: string,
   query: {
     [key: string]: string,
   },

--- a/src/lib/TrackingEventBackend.js
+++ b/src/lib/TrackingEventBackend.js
@@ -7,7 +7,7 @@ import { getUserAgent } from './userAgent';
 import { hasAllowedAnalytics, getUUID, getJoinedMappingEventId } from './savedState';
 import { userPositionTracker } from './UserPositionTracker';
 import { mappingEventsCache } from '../lib/cache/MappingEventsCache';
-import { type AppContext } from '../AppContext';
+import { type App } from '../lib/App';
 
 export type AttributeChangedTrackingEvent = {
   type: 'AttributeChanged',
@@ -23,18 +23,44 @@ export type SurveyCompletedTrackingEvent = {
   uniqueSurveyId: string,
 };
 
-export type TrackingEvent = AttributeChangedTrackingEvent | SurveyCompletedTrackingEvent;
+export type AppOpenedTrackingEvent = {
+  type: 'AppOpened',
+  query: {
+    [key: string]: string,
+  },
+};
+
+export type MappingEventJoinedTrackingEvent = {
+  type: 'MappingEventJoined',
+  joinedVia: 'url' | 'button',
+  query: {
+    [key: string]: string,
+  },
+};
+
+export type MappingEventLeftTrackingEvent = {
+  type: 'MappingEventLeft',
+  query: {
+    [key: string]: string,
+  },
+};
+
+export type TrackingEvent =
+  | AttributeChangedTrackingEvent
+  | SurveyCompletedTrackingEvent
+  | AppOpenedTrackingEvent
+  | MappingEventJoinedTrackingEvent
+  | MappingEventLeftTrackingEvent;
 
 export default class TrackingEventBackend {
-  async track(appContext: AppContext, event: TrackingEvent): Promise<boolean> {
+  async track(app: App, event: TrackingEvent): Promise<boolean> {
     if (!hasAllowedAnalytics()) {
       return Promise.reject(false);
     }
 
     const joinedMappingEventId = getJoinedMappingEventId();
     const mappingEvent =
-      joinedMappingEventId &&
-      (await mappingEventsCache.getMappingEvent(appContext.app, joinedMappingEventId));
+      joinedMappingEventId && (await mappingEventsCache.getMappingEvent(app, joinedMappingEventId));
 
     // get userLocation
     const userLocation = userPositionTracker.userLocation;


### PR DESCRIPTION
Three new Event Types exist now:

* `AppOpened` is sent when the app is opened the website is reloaded
* `MappingEventJoined` is sent when the user joins the mapping event either by the join URL or by manually clicking the button. The two cases are distinguishable by the property `joinedVia = 'url' | 'button'` within the event.
* `MappingEventLeft` is sent when the user leaves the event by clicking the leave button on the event detail page. The event comes with an extra property of `leftMappingEventId` that signifies the just left mapping event

Also small change: The `trackingEventBackend.track()` function now expects the app and not the app context.