### PR TITLE
Fix Vanishing Halos

### DIFF
--- a/src/components/icons/markers/mappingEventHalo.js
+++ b/src/components/icons/markers/mappingEventHalo.js
@@ -3,11 +3,25 @@ import React from 'react';
 const MappingEventHalo = props => (
   <svg viewBox="0 0 444 444" width="1em" height="1em" {...props}>
     <defs>
-      <filter x="-75%" y="-75%" width="250%" height="250%" filterUnits="objectBoundingBox" id="a">
+      <filter
+        x="-75%"
+        y="-75%"
+        width="250%"
+        height="250%"
+        filterUnits="objectBoundingBox"
+        id="mapping-event-halo-filter"
+      >
         <feGaussianBlur stdDeviation={50} in="SourceGraphic" />
       </filter>
     </defs>
-    <circle fill="#226BE59A" filter="url(#a)" cx={222} cy={222} r={100} fillRule="evenodd" />
+    <circle
+      fill="#226BE59A"
+      filter="url(#mapping-event-halo-filter)"
+      cx={222}
+      cy={222}
+      r={100}
+      fillRule="evenodd"
+    />
   </svg>
 );
 


### PR DESCRIPTION
This was one of the weirdest/hardest bugs in a long time 😬

The search button uses an SVG inside. The mapping event halo is an SVG. Both SVGs when being displayed concurrently came in conflict with each other because the search button was using a an SVG `<linearGradient id="a"`> and the mapping event halo was using an SVG `<filter id="a">`.
The id `a` is then subsequently referenced in both SVGs for different purposes. So ultimately one was overriding the other.
It seems that any definitions inside an `<svg>` tag need to be uniquely id-ed across all `<svg>` tags on the page.

So I gave the halo SVG a more unique id.