### PR TITLE
Make Mapping Event Header Click Fly The Map Back To Event Marker

### DIFF
--- a/src/MainView.js
+++ b/src/MainView.js
@@ -245,6 +245,8 @@ class MainView extends React.Component<Props, State> {
     }
   };
 
+  onMappingEventHeaderClick = () => this.map && this.map.snapToFeature();
+
   onAddPlaceLinkClick = () => {
     this.setState(() => ({ uniqueSurveyId: uuidv4() }));
   };
@@ -323,6 +325,7 @@ class MainView extends React.Component<Props, State> {
         joinedMappingEventId={joinedMappingEventId}
         mappingEventHandlers={mappingEventHandlers}
         onClose={onCloseMappingEventsToolbar}
+        onHeaderClick={this.onMappingEventHeaderClick}
         productName={translatedProductName}
         focusTrapActive={focusTrapActive}
       />

--- a/src/components/MappingEvents/MappingEventToolbar.js
+++ b/src/components/MappingEvents/MappingEventToolbar.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { type KeyboardEvent } from 'react';
 import { t } from 'ttag';
 import styled from 'styled-components';
 import FocusTrap from 'focus-trap-react';
@@ -26,6 +26,7 @@ interface MappingEventToolbarProps {
     updateJoinedMappingEvent: (joinedMappingEventId: ?string) => void,
   };
   onClose: () => void;
+  onHeaderClick: () => void;
   productName: string;
   focusTrapActive: Boolean;
 }
@@ -36,6 +37,7 @@ const MappingEventToolbar = ({
   mappingEventHandlers: { updateJoinedMappingEvent },
   joinedMappingEventId,
   onClose,
+  onHeaderClick,
   productName,
   focusTrapActive,
 }: MappingEventToolbarProps) => {
@@ -82,6 +84,9 @@ const MappingEventToolbar = ({
     </PrimaryButton>
   );
 
+  const onHeaderKeyPress = (event: KeyboardEvent<HTMLDivElement>) =>
+    event.key === 'Enter' && onHeaderClick();
+
   return (
     <FocusTrap active={focusTrapActive} focusTrapOptions={{ clickOutsideDeactivates: true }}>
       <Toolbar className={className} ariaLabel={toolbarAriaLabel} role="dialog">
@@ -101,7 +106,7 @@ const MappingEventToolbar = ({
               }}
             </RouteConsumer>
           )}
-          <div>
+          <div onClick={onHeaderClick} role="button" tabIndex="0" onKeyPress={onHeaderKeyPress}>
             <h2>{mappingEvent.name}</h2>
             <p>{dateString}</p>
             <address>

--- a/src/lib/Feature.js
+++ b/src/lib/Feature.js
@@ -224,6 +224,9 @@ export function getFeatureId(feature: Feature | EquipmentInfo): ?string {
     typeof feature._id === 'string' && feature._id,
     feature.properties && typeof feature.properties.id === 'number' && feature.properties.id,
     feature.properties && typeof feature.properties._id === 'string' && feature.properties._id,
+    feature.properties &&
+      typeof feature.properties.osm_id === 'number' &&
+      feature.properties.osm_id,
   ];
   const result = idProperties.filter(Boolean)[0];
   return result ? String(result) : null;


### PR DESCRIPTION
There were two parts to this:

* a click handler to the mapping event header
* and adapting `getFeatureId` so that it also extract the `osm_id` for features of type `SearchResultFeature`