### PR TITLE
Fix Darkening Map on Focus

### DIFF
--- a/src/components/Map/Map.css
+++ b/src/components/Map/Map.css
@@ -40,7 +40,7 @@ body.is-touch-device .leaflet-control-zoom {
   }
 }
 
-.leaflet-container.focus-visible::after {
+.leaflet-container.focus-visible::before {
   content: "";
   border-radius: 4px;
   box-shadow: inset 0px 0px 0px 6px #4469e1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8977,7 +8977,7 @@ lcid@^2.0.0:
 
 leaflet-gesture-handling@sozialhelden/Leaflet.GestureHandling:
   version "1.1.8"
-  resolved "https://codeload.github.com/sozialhelden/Leaflet.GestureHandling/tar.gz/2960dc02100c97443fc89694500edd2c29d95495"
+  resolved "https://codeload.github.com/sozialhelden/Leaflet.GestureHandling/tar.gz/ff6ec8de9526396fe114af90a26cf048254b3760"
 
 leaflet-tilelayer-geojson@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
There was a conflict of CSS `after` pseudo elements. The new `leaflet-gesture-handling` plugin used a similar CSS selector (`.leaflet-container::after`) to ours for the focus ring of the map (`.leaflet-container.focus-visible::after`). So when `.focus-visible` was added to the leaflet container by tabbing, the `after` pseudo element was created and with it came additional CSS rules from the plugin which we don't want.

So I just decided to use a `before` pseudo element to avoid that conflict.