### PR TITLE
Fix Node Header Issues

### DIFF
--- a/src/components/MappingEvents/MappingEventsToolbar.js
+++ b/src/components/MappingEvents/MappingEventsToolbar.js
@@ -86,8 +86,7 @@ const StyledMappingEventsToolbar = styled(MappingEventsToolbar)`
   header {
     display: flex;
     align-items: center;
-    margin-top: 10px;
-    margin-bottom: 10px;
+    padding: 0.5rem 0;
   }
 
   h2 {

--- a/src/components/NodeToolbar/FeatureClusterPanel.js
+++ b/src/components/NodeToolbar/FeatureClusterPanel.js
@@ -37,9 +37,9 @@ type State = {
 };
 
 const PositionedCloseLink = styled(StyledCloseLink)`
+  position: absolute;
   top: 0;
-  z-index: 4;
-  margin: -5px -16px -2px -2px; /* move close button to the same position as in search toolbar */
+  right: 0;
 `;
 PositionedCloseLink.displayName = 'PositionedCloseLink';
 
@@ -157,9 +157,9 @@ class UnstyledFeatureClusterPanel extends React.Component<Props, State> {
             // We need to set clickOutsideDeactivates here as we want clicks on e.g. the map markers to not be prevented.
             focusTrapOptions={{ clickOutsideDeactivates: true }}
           >
-            {this.renderCloseLink()}
             <section className="cluster-entries">
               <StyledNodeHeader>
+                {this.renderCloseLink()}
                 <PlaceName>
                   <StyledClusterIcon {...this.props} />
                   {placesLabel}

--- a/src/components/NodeToolbar/FeatureClusterPanel.js
+++ b/src/components/NodeToolbar/FeatureClusterPanel.js
@@ -37,9 +37,9 @@ type State = {
 };
 
 const PositionedCloseLink = styled(StyledCloseLink)`
-  position: absolute;
-  top: 0;
-  right: 0;
+  align-self: flex-start;
+  margin-top: -8px;
+  margin-right: 1px;
 `;
 PositionedCloseLink.displayName = 'PositionedCloseLink';
 
@@ -159,11 +159,11 @@ class UnstyledFeatureClusterPanel extends React.Component<Props, State> {
           >
             <section className="cluster-entries">
               <StyledNodeHeader>
-                {this.renderCloseLink()}
                 <PlaceName>
                   <StyledClusterIcon {...this.props} />
                   {placesLabel}
                 </PlaceName>
+                {this.renderCloseLink()}
               </StyledNodeHeader>
               <StyledFrame className="entry-list">
                 <ul>{this.renderClusterEntries(cluster.features)}</ul>

--- a/src/components/NodeToolbar/NodeHeader.js
+++ b/src/components/NodeToolbar/NodeHeader.js
@@ -35,6 +35,10 @@ export const StyledNodeHeader = styled.header`
   transition: box-shadow 0.3s ease-out;
   box-shadow: ${props =>
     props.hasShadow ? '0 0 33px rgba(0, 0, 0, 0.1)' : '0 0 33px rgba(0, 0, 0, 0)'};
+
+  ${PlaceName} {
+    flex-grow: 2;
+  }
 `;
 
 const StyledBreadCrumbs = styled(BreadCrumbs)`
@@ -128,9 +132,9 @@ export default class NodeHeader extends React.Component<Props> {
 
     return (
       <StyledNodeHeader hasShadow={this.props.hasShadow}>
-        {children}
         {clusterElement}
         {placeNameElement}
+        {children}
       </StyledNodeHeader>
     );
   }

--- a/src/components/NodeToolbar/NodeHeader.js
+++ b/src/components/NodeToolbar/NodeHeader.js
@@ -43,6 +43,7 @@ const StyledBreadCrumbs = styled(BreadCrumbs)`
 `;
 
 type Props = {
+  children?: React.Node,
   feature: ?Feature,
   equipmentInfoId: ?string,
   equipmentInfo: ?EquipmentInfo,
@@ -71,7 +72,7 @@ export default class NodeHeader extends React.Component<Props> {
     const properties = feature.properties;
     if (!properties) return null;
 
-    const { category, parentCategory } = this.props;
+    const { category, parentCategory, children } = this.props;
     const shownCategory = category || parentCategory;
     let categoryName = shownCategory && categoryNameFor(shownCategory);
     const shownCategoryId = shownCategory && getCategoryId(shownCategory);
@@ -127,6 +128,7 @@ export default class NodeHeader extends React.Component<Props> {
 
     return (
       <StyledNodeHeader hasShadow={this.props.hasShadow}>
+        {children}
         {clusterElement}
         {placeNameElement}
       </StyledNodeHeader>

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -40,9 +40,9 @@ import { type SourceWithLicense } from '../../app/PlaceDetailsProps';
 import { type Cluster } from '../Map/Cluster';
 
 const PositionedCloseLink = styled(CloseLink)`
+  position: absolute;
   top: 0;
-  z-index: 4;
-  margin: -5px -16px -2px -2px; /* move close button to the same position as in search toolbar */
+  right: 0;
 `;
 PositionedCloseLink.displayName = 'PositionedCloseLink';
 
@@ -182,7 +182,9 @@ class NodeToolbar extends React.Component<Props, State> {
         onClickCurrentMarkerIcon={onClickCurrentMarkerIcon}
         hasIcon={hasIcon}
         hasShadow={this.state.isScrollable}
-      />
+      >
+        {this.renderCloseLink()}
+      </NodeHeader>
     );
   }
 
@@ -367,7 +369,6 @@ class NodeToolbar extends React.Component<Props, State> {
             // We need to set clickOutsideDeactivates here as we want clicks on e.g. the map markers to not be prevented.
             focusTrapOptions={{ clickOutsideDeactivates: true }}
           >
-            {this.renderCloseLink()}
             {this.renderNodeHeader()}
             {this.renderContentBelowHeader()}
           </FocusTrap>

--- a/src/components/NodeToolbar/NodeToolbar.js
+++ b/src/components/NodeToolbar/NodeToolbar.js
@@ -40,9 +40,9 @@ import { type SourceWithLicense } from '../../app/PlaceDetailsProps';
 import { type Cluster } from '../Map/Cluster';
 
 const PositionedCloseLink = styled(CloseLink)`
-  position: absolute;
-  top: 0;
-  right: 0;
+  align-self: flex-start;
+  margin-top: -8px;
+  margin-right: 1px;
 `;
 PositionedCloseLink.displayName = 'PositionedCloseLink';
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -422,12 +422,13 @@ const StyledToolbar = styled(Toolbar)`
       display: block;
       position: sticky;
       top: 0;
+      left: 50%;
       z-index: 3;
-      width: 100%;
+      width: 50%;
       height: 10px;
       margin: -10px 0 -20px 0;
       padding: 15px;
-      transform: translateZ(0);
+      transform: translateZ(0) translateX(-50%);
       touch-action: none;
       background-color: transparent;
       &:before {


### PR DESCRIPTION
This PR fixes the upper extra margin on Safari due to different results of using `position: sticky`, by putting the close button within the header and only let the whole header be sticky.

This also solves the "visual gap" between header and button when the toolbar is scrollable.

As another optimization I made the grab-handle narrower in width so we can avoid click target conflicts with the header icon button or the close button.
