### PR TITLE
Fix Wrong Data Formatting on MappingEventToolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "focus-trap-react": "^6.0.0",
     "focus-visible": "^4.1.5",
     "focus-within": "^2.0.0",
+    "full-icu": "^1.3.0",
     "geojson-flow": "^1.0.1",
     "gettext-parser": "^1.3.0",
     "glob": "^5.0.15",
@@ -144,8 +145,8 @@
     "write-file-webpack-plugin": "^4.4.1"
   },
   "scripts": {
-    "dev": "nodemon --inspect --watch src/server.js --watch src/app/router.js src/server.js",
-    "start": "NODE_ENV=production node src/server.js",
+    "dev": "nodemon --icu-data-dir=node_modules/full-icu --inspect --watch src/server.js --watch src/app/router.js src/server.js",
+    "start": "NODE_ENV=production node --icu-data-dir=node_modules/full-icu src/server.js",
     "build": "rm -rf src/.next/* && next build src/",
     "analyze": "source-map-explorer build/static/js/main.*",
     "test": "node scripts/test.js --env=jsdom",

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -10,6 +10,7 @@ export type AppContext = {
   app?: App,
   baseUrl: string,
   categories: CategoryLookupTables,
+  preferredLanguage?: string,
 };
 
 const { Provider, Consumer } = createContext<AppContext>({

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -319,15 +319,20 @@ class MainView extends React.Component<Props, State> {
     const focusTrapActive = !this.isAnyDialogVisible();
 
     return (
-      <MappingEventToolbar
-        mappingEvent={mappingEvent}
-        joinedMappingEventId={joinedMappingEventId}
-        mappingEventHandlers={mappingEventHandlers}
-        onClose={onCloseMappingEventsToolbar}
-        onHeaderClick={this.onMappingEventHeaderClick}
-        productName={translatedProductName}
-        focusTrapActive={focusTrapActive}
-      />
+      <AppContextConsumer>
+        {({ preferredLanguage }) => (
+          <MappingEventToolbar
+            mappingEvent={mappingEvent}
+            joinedMappingEventId={joinedMappingEventId}
+            mappingEventHandlers={mappingEventHandlers}
+            onClose={onCloseMappingEventsToolbar}
+            onHeaderClick={this.onMappingEventHeaderClick}
+            productName={translatedProductName}
+            focusTrapActive={focusTrapActive}
+            preferredLanguage={preferredLanguage}
+          />
+        )}
+      </AppContextConsumer>
     );
   }
 

--- a/src/components/MappingEvents/MappingEventToolbar.js
+++ b/src/components/MappingEvents/MappingEventToolbar.js
@@ -29,6 +29,7 @@ interface MappingEventToolbarProps {
   onHeaderClick: () => void;
   productName: string;
   focusTrapActive: Boolean;
+  preferredLanguage: string;
 }
 
 const MappingEventToolbar = ({
@@ -40,6 +41,7 @@ const MappingEventToolbar = ({
   onHeaderClick,
   productName,
   focusTrapActive,
+  preferredLanguage,
 }: MappingEventToolbarProps) => {
   const startDate = new Date(mappingEvent.startTime);
   const endDate = mappingEvent.endTime ? new Date(mappingEvent.endTime) : null;
@@ -49,9 +51,20 @@ const MappingEventToolbar = ({
       ? buildFullImageUrl(mappingEvent.images[0])
       : '/static/images/eventPlaceholder.png';
 
-  let dateString = `${startDate.toLocaleDateString()} ${startDate.toLocaleTimeString()}`;
+  const dateFormatOptions = {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  };
+
+  let startDateString = Intl.DateTimeFormat(preferredLanguage, dateFormatOptions).format(startDate);
+  let endDateString = null;
+
   if (endDate) {
-    dateString += ` - ${endDate.toLocaleDateString()} ${endDate.toLocaleTimeString()}`;
+    startDateString += ' -';
+    endDateString = Intl.DateTimeFormat(preferredLanguage, dateFormatOptions).format(endDate);
   }
 
   const areaName = mappingEvent.area.properties.name;
@@ -108,7 +121,8 @@ const MappingEventToolbar = ({
           )}
           <div onClick={onHeaderClick} role="button" tabIndex="0" onKeyPress={onHeaderKeyPress}>
             <h2>{mappingEvent.name}</h2>
-            <p>{dateString}</p>
+            <p>{startDateString}</p>
+            {endDateString && <p>{endDateString}</p>}
             <address>
               {areaName && <p>{areaName}</p>}
               {meetingPointName && <p>{meetingPointName}</p>}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -76,6 +76,7 @@ export default class App extends BaseApp {
     let appProps;
     let routeProps;
     let path;
+    let localeStrings: string[] = [];
 
     isServer = !!(ctx && ctx.req);
 
@@ -99,8 +100,6 @@ export default class App extends BaseApp {
       }
 
       // translations
-      let localeStrings: string[] = [];
-
       if (ctx.req) {
         if (ctx.req.headers['accept-language']) {
           localeStrings = parseAcceptLanguageString(ctx.req.headers['accept-language']);
@@ -167,6 +166,7 @@ export default class App extends BaseApp {
       ...routeProps,
       skipApplicationBody: isTwitterBot,
       routeName: ctx.query.routeName,
+      preferredLanguage: localeStrings[0],
       path,
       isCordovaBuild,
     };
@@ -208,6 +208,7 @@ export default class App extends BaseApp {
       skipApplicationBody,
       rawCategoryLists,
       buildTimeProps,
+      preferredLanguage,
       ...appProps
     } = receivedProps;
 
@@ -312,6 +313,7 @@ export default class App extends BaseApp {
       app: this.props.app,
       baseUrl,
       categories: appProps.categories,
+      preferredLanguage,
     };
 
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6541,6 +6541,11 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2, fstream@~1.0.10:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+full-icu@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.3.0.tgz#1fb4d60050103ad9dcf53735c000e4a03d80c574"
+  integrity sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==
+
 function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1, function-bind@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
Our logic for language code determination was unfortunately not suitable for date formatting. We are lenient when it comes to translations and more specific language codes like `en-CA` are also covered by `en` translation as a fallback if the latter exists and the first doesn't.

Date and number formatting are highly specific per region/country though. So we have to be more strict here. That's why I added an unprocessed (without fallbacks) language code to the `AppContext`. 
We already had this language code retrieved at the very beginning of `_app.js#getInitialProps`, so I just took it from there and passed it down into the `AppContext`.

As we discussed the SSR side does not format dates correctly, because of missing locale data in node. So I tried and added the `full-icu` package and seems to work well.

We could also decide to not use that package and just accept that the first render will display dates wrong and then it would flash to the right format once client side rendering kicks in.