### PR TITLE
Cleanup Search Input Fix

### DIFF
--- a/src/components/SearchToolbar/SearchInputField.js
+++ b/src/components/SearchToolbar/SearchInputField.js
@@ -21,23 +21,8 @@ type Props = {
   ariaRole: string,
 };
 
-type State = {
-  value: ?string,
-};
-
 class SearchInputField extends React.Component<Props, State> {
   input: ?HTMLInputElement;
-
-  state = {
-    value: null,
-  };
-
-  getDerivedStateFromProps(nextProps) {
-    const value = nextProps.placeholder || nextProps.searchQuery || '';
-    return {
-      value,
-    };
-  }
 
   focus() {
     if (!this.input) return;
@@ -70,12 +55,9 @@ class SearchInputField extends React.Component<Props, State> {
     // translator: Placeholder for search input field
     const defaultPlaceholder = t`Search for place or address`;
 
-    const { value } = this.state;
-
     return (
       <input
         ref={input => (this.input = input)}
-        value={value}
         name="search"
         onChange={onChange}
         disabled={disabled}
@@ -85,7 +67,7 @@ class SearchInputField extends React.Component<Props, State> {
         onClick={onClick}
         onKeyPress={this.keyPressed}
         className={`search-input ${className}`}
-        placeholder={!value ? defaultPlaceholder : null}
+        placeholder={defaultPlaceholder}
         aria-label={defaultPlaceholder}
         role={ariaRole}
         autoComplete="off"

--- a/src/components/SearchToolbar/SearchInputField.js
+++ b/src/components/SearchToolbar/SearchInputField.js
@@ -8,34 +8,30 @@ import { t } from 'ttag';
 
 type Props = {
   onSubmit: ?(event: UIEvent) => void,
-  onChange: ?(event: UIEvent) => void,
+  onChange: (value: string) => void,
   onBlur: ?(event: UIEvent) => void,
   onFocus: ?(event: UIEvent) => void,
   onClick: ?(event: UIEvent) => void,
   ref: (input: HTMLInputElement) => void,
   searchQuery: ?string,
   className: string,
-  placeholder: ?string,
   disabled: ?boolean,
   hidden: boolean,
   ariaRole: string,
 };
 
 type State = {
-  value: ?string,
+  value: string,
 };
 
 class SearchInputField extends React.Component<Props, State> {
   input: ?HTMLInputElement;
 
-  state = {
-    value: null,
-  };
+  constructor(props) {
+    super(props);
 
-  getDerivedStateFromProps(nextProps) {
-    const value = nextProps.placeholder || nextProps.searchQuery || '';
-    return {
-      value,
+    this.state = {
+      value: props.searchQuery || '',
     };
   }
 
@@ -56,28 +52,24 @@ class SearchInputField extends React.Component<Props, State> {
     }
   };
 
+  onChange = event => {
+    const value = event.target.value;
+    this.setState({ value });
+    this.props.onChange(value);
+  };
+
   render() {
-    const {
-      onChange,
-      disabled,
-      hidden,
-      onFocus,
-      onBlur,
-      onClick,
-      className,
-      ariaRole,
-    } = this.props;
+    const { disabled, hidden, onFocus, onBlur, onClick, className, ariaRole } = this.props;
+    const { value } = this.state;
     // translator: Placeholder for search input field
     const defaultPlaceholder = t`Search for place or address`;
-
-    const { value } = this.state;
 
     return (
       <input
         ref={input => (this.input = input)}
         value={value}
         name="search"
-        onChange={onChange}
+        onChange={this.onChange}
         disabled={disabled}
         tabIndex={hidden ? -1 : 0}
         onFocus={onFocus}
@@ -85,7 +77,7 @@ class SearchInputField extends React.Component<Props, State> {
         onClick={onClick}
         onKeyPress={this.keyPressed}
         className={`search-input ${className}`}
-        placeholder={!value ? defaultPlaceholder : null}
+        placeholder={defaultPlaceholder}
         aria-label={defaultPlaceholder}
         role={ariaRole}
         autoComplete="off"

--- a/src/components/SearchToolbar/SearchInputField.js
+++ b/src/components/SearchToolbar/SearchInputField.js
@@ -21,8 +21,23 @@ type Props = {
   ariaRole: string,
 };
 
+type State = {
+  value: ?string,
+};
+
 class SearchInputField extends React.Component<Props, State> {
   input: ?HTMLInputElement;
+
+  state = {
+    value: null,
+  };
+
+  getDerivedStateFromProps(nextProps) {
+    const value = nextProps.placeholder || nextProps.searchQuery || '';
+    return {
+      value,
+    };
+  }
 
   focus() {
     if (!this.input) return;
@@ -55,9 +70,12 @@ class SearchInputField extends React.Component<Props, State> {
     // translator: Placeholder for search input field
     const defaultPlaceholder = t`Search for place or address`;
 
+    const { value } = this.state;
+
     return (
       <input
         ref={input => (this.input = input)}
+        value={value}
         name="search"
         onChange={onChange}
         disabled={disabled}
@@ -67,7 +85,7 @@ class SearchInputField extends React.Component<Props, State> {
         onClick={onClick}
         onKeyPress={this.keyPressed}
         className={`search-input ${className}`}
-        placeholder={defaultPlaceholder}
+        placeholder={!value ? defaultPlaceholder : null}
         aria-label={defaultPlaceholder}
         role={ariaRole}
         autoComplete="off"

--- a/src/components/SearchToolbar/SearchToolbar.js
+++ b/src/components/SearchToolbar/SearchToolbar.js
@@ -237,10 +237,6 @@ export default class SearchToolbar extends React.PureComponent<Props, State> {
   goButton: ?React.ElementRef<'button'> = null;
   firstResult: ?React.ElementRef<typeof SearchResult> = null;
 
-  onChangeSearchQuery = (event: SyntheticEvent<HTMLInputElement>) => {
-    this.props.onChangeSearchQuery(event.target.value);
-  };
-
   static getDerivedStateFromProps(props: Props, state: State) {
     const { searchResults } = props;
 
@@ -364,7 +360,7 @@ export default class SearchToolbar extends React.PureComponent<Props, State> {
             this.ensureFullVisibility();
           }, 300);
         }}
-        onChange={this.onChangeSearchQuery}
+        onChange={this.props.onChangeSearchQuery}
         onSubmit={event => {
           this.setState({ searchFieldIsFocused: false }, () => {
             this.blur();


### PR DESCRIPTION
**Updated**

After reading through a lot of misinformation and also testing a few things myself it appears that this comment by Dan Abramov brought the solution:

https://github.com/facebook/react/issues/955#issuecomment-469352730

Using `setState` within the component with the input field (in addition to calling the passed in `onChange`) seems to both preserve the cursor position and therefore not tamper with different input methods and also updates the URL.

Why using `setState` here helps though is beyond my knowledge. I guess it's a React Thing 🤔🤷🏻‍♂️