### PR TITLE
Fix Issues Surrounding "Planned" Events

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -270,7 +270,10 @@ class App extends React.Component<Props, State> {
   isMappingEventOngoing(mappingEventId: ?string, mappingEvents: MappingEvents) {
     if (mappingEventId) {
       const joinedMappingEvent = mappingEvents.find(event => event._id === mappingEventId);
-      return joinedMappingEvent && joinedMappingEvent.status === 'ongoing';
+      return (
+        joinedMappingEvent &&
+        (joinedMappingEvent.status === 'ongoing' || joinedMappingEvent.status === 'planned')
+      );
     }
 
     return false;

--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,7 @@ import { type SearchResultCollection } from './lib/searchPlaces';
 import type { Feature, WheelmapFeature } from './lib/Feature';
 import type { SearchResultFeature } from './lib/searchPlaces';
 import type { EquipmentInfo, EquipmentInfoProperties } from './lib/EquipmentInfo';
-import type { MappingEvents, MappingEvent } from './lib/MappingEvent';
+import { type MappingEvents, type MappingEvent, isMappingEventVisible } from './lib/MappingEvent';
 import { type Cluster } from './components/Map/Cluster';
 import { type App as AppModel } from './lib/App';
 
@@ -270,10 +270,7 @@ class App extends React.Component<Props, State> {
   isMappingEventOngoing(mappingEventId: ?string, mappingEvents: MappingEvents) {
     if (mappingEventId) {
       const joinedMappingEvent = mappingEvents.find(event => event._id === mappingEventId);
-      return (
-        joinedMappingEvent &&
-        (joinedMappingEvent.status === 'ongoing' || joinedMappingEvent.status === 'planned')
-      );
+      return joinedMappingEvent && isMappingEventVisible(joinedMappingEvent);
     }
 
     return false;

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -50,7 +50,7 @@ import colors, { interpolateWheelchairAccessibility } from '../../lib/colors';
 import useImperialUnits from '../../lib/useImperialUnits';
 import { tileLoadingStatus } from './trackTileLoadingState';
 import { type Cluster } from './Cluster';
-import type { MappingEvents } from '../../lib/MappingEvent';
+import { type MappingEvents, isMappingEventVisible } from '../../lib/MappingEvent';
 import A11yMarkerIcon from './A11yMarkerIcon';
 import MappingEventMarkerIcon from './MappingEventMarkerIcon';
 
@@ -572,12 +572,7 @@ export default class Map extends React.Component<Props, State> {
 
     this.props.mappingEvents &&
       this.props.mappingEvents
-        .filter(
-          event =>
-            event.status === 'ongoing' ||
-            event.status === 'planned' ||
-            event._id === this.props.featureId
-        )
+        .filter(event => isMappingEventVisible(event) || event._id === this.props.featureId)
         .forEach(event => {
           const eventFeature = event.meetingPoint;
 

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -572,7 +572,12 @@ export default class Map extends React.Component<Props, State> {
 
     this.props.mappingEvents &&
       this.props.mappingEvents
-        .filter(event => event.status === 'ongoing' || event._id === this.props.featureId)
+        .filter(
+          event =>
+            event.status === 'ongoing' ||
+            event.status === 'planned' ||
+            event._id === this.props.featureId
+        )
         .forEach(event => {
           const eventFeature = event.meetingPoint;
 

--- a/src/components/MappingEvents/MappingEventToolbar.js
+++ b/src/components/MappingEvents/MappingEventToolbar.js
@@ -15,7 +15,7 @@ import { AppContextConsumer } from '../../AppContext';
 import ChevronLeft from './ChevronLeft';
 import CloseButton from './CloseButton';
 import { buildFullImageUrl } from '../../lib/Image';
-import type { MappingEvent } from '../../lib/MappingEvent';
+import { type MappingEvent, isMappingEventVisible } from '../../lib/MappingEvent';
 import { PrimaryButton, ChromelessButton, DangerButton } from '../Button';
 
 interface MappingEventToolbarProps {
@@ -148,8 +148,7 @@ const MappingEventToolbar = ({
           </div>
         </section>
         <div className="actions">
-          {(mappingEvent.status === 'ongoing' || mappingEvent.status === 'planned') &&
-            eventJoinOrLeaveButton}
+          {isMappingEventVisible(mappingEvent) && eventJoinOrLeaveButton}
           <AppContextConsumer>
             {appContext => (
               <MappingEventShareBar

--- a/src/components/MappingEvents/MappingEventsToolbar.js
+++ b/src/components/MappingEvents/MappingEventsToolbar.js
@@ -8,6 +8,7 @@ import Link, { RouteConsumer } from '../Link/Link';
 import CloseButton from './CloseButton';
 import { MappingEvents } from '../../lib/cache/MappingEventsCache';
 import { App } from '../../lib/App';
+import { isMappingEventVisible } from '../../lib/MappingEvent';
 
 type MappingEventsToolbarProps = {
   app: App,
@@ -34,7 +35,7 @@ const MappingEventsToolbar = ({
   const mappingEventsTagLine = t`Meet the community and map the accessibility of places around you!`;
 
   const listedMappingEvents = mappingEvents
-    .filter(event => event.status === 'ongoing' || event.status === 'planned')
+    .filter(isMappingEventVisible)
     .filter(event => event.appId === app._id);
 
   return (

--- a/src/lib/MappingEvent.js
+++ b/src/lib/MappingEvent.js
@@ -38,3 +38,6 @@ export type MappingEvents = MappingEvent[];
 
 export const hrefForMappingEvent = (mappingEvent: MappingEvent): string =>
   `/events/${mappingEvent._id}`;
+
+export const isMappingEventVisible = (mappingEvent: MappingEvent): boolean =>
+  mappingEvent.status === 'ongoing' || mappingEvent.status === 'planned';


### PR DESCRIPTION
There were a couple of things we forgot to add to make "planned" events treated as "ongoing" events.

* Show planned events on the map as well
* Add planned events to the "is event ongoing" logic when checking if local storage value for active event has to be reset