### PR TITLE
Make Event Markers Appear Behind Every Other Marker

### DIFF
--- a/src/components/Map/HighlightableMarker.js
+++ b/src/components/Map/HighlightableMarker.js
@@ -5,11 +5,18 @@ import L from 'leaflet';
 export default class HighlightableMarker extends L.Marker {
   highlightedMarker: L.Marker | null = null;
 
-  constructor(latlng: L.LatLng, markerIconType, markerIconOptions, featureId?: string) {
+  constructor(
+    latlng: L.LatLng,
+    markerIconType,
+    markerIconOptions,
+    featureId?: string,
+    zIndexOffset?: number = 0
+  ) {
     const markerIcon = new markerIconType(markerIconOptions);
 
     super(latlng, {
       icon: markerIcon,
+      zIndexOffset: zIndexOffset,
     });
 
     this.markerIcon = markerIcon;

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -600,7 +600,8 @@ export default class Map extends React.Component<Props, State> {
               href: hrefForMappingEvent(event),
               onClick: () => this.props.onMappingEventClick(event._id),
             },
-            event._id
+            event._id,
+            -1000
           );
 
           this.mappingEventsLayer && this.mappingEventsLayer.addLayer(eventMarker);


### PR DESCRIPTION
This PR adds a negative `zIndexOffset` to mapping event markers, so that they appear behind any other marker in the marker pane of the map.

This is not ideal because cluster groups in certain zoom levels could cover the event markers completely.

Still a POI or cluster number should never be covered by an event marker and thus be not clickable, so that's why we are doing it this way.