### PR TITLE
Make Map Not Locate On Start When Lat Lon Is Specified

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -889,11 +889,10 @@ class App extends React.Component<Props, State> {
     const { isSpecificLatLonProvided } = this.state;
     const isNodeRoute = Boolean(this.props.featureId);
     const isNodeToolbarDisplayed = this.isNodeToolbarDisplayed();
+    const mapMoveDate = savedState.map.lastMoveDate;
+    const wasMapMovedRecently = mapMoveDate && new Date() - mapMoveDate < config.locateTimeout;
 
-    const shouldLocateOnStart =
-      !isSpecificLatLonProvided &&
-      !isNodeRoute &&
-      +new Date() - (savedState.map.lastMoveDate || 0) > config.locateTimeout;
+    const shouldLocateOnStart = !isSpecificLatLonProvided && !isNodeRoute && !wasMapMovedRecently;
 
     const isSearchBarVisible = this.state.isSearchBarVisible;
     const isMappingEventsToolbarVisible = this.state.isMappingEventsToolbarVisible;

--- a/src/App.js
+++ b/src/App.js
@@ -122,6 +122,7 @@ type State = {
   // map controls
   lat?: ?number,
   lon?: ?number,
+  isSpecificLatLonProvided: boolean,
   zoom?: ?number,
   extent?: ?[number, number, number, number],
 };
@@ -136,6 +137,7 @@ class App extends React.Component<Props, State> {
   state: State = {
     lat: null,
     lon: null,
+    isSpecificLatLonProvided: false,
     zoom: null,
     mappingEvents: this.props.mappingEvents,
 
@@ -228,6 +230,8 @@ class App extends React.Component<Props, State> {
       state.lat || parsedLat || (savedState.map.lastCenter && savedState.map.lastCenter[0]) || null;
     newState.lon =
       state.lon || parsedLon || (savedState.map.lastCenter && savedState.map.lastCenter[1]) || null;
+
+    newState.isSpecificLatLonProvided = Boolean(parsedLat) && Boolean(parsedLon);
 
     return newState;
   }
@@ -882,11 +886,14 @@ class App extends React.Component<Props, State> {
   };
 
   render() {
+    const { isSpecificLatLonProvided } = this.state;
     const isNodeRoute = Boolean(this.props.featureId);
     const isNodeToolbarDisplayed = this.isNodeToolbarDisplayed();
 
     const shouldLocateOnStart =
-      !isNodeRoute && +new Date() - (savedState.map.lastMoveDate || 0) > config.locateTimeout;
+      !isSpecificLatLonProvided &&
+      !isNodeRoute &&
+      +new Date() - (savedState.map.lastMoveDate || 0) > config.locateTimeout;
 
     const isSearchBarVisible = this.state.isSearchBarVisible;
     const isMappingEventsToolbarVisible = this.state.isMappingEventsToolbarVisible;


### PR DESCRIPTION
This fixes: [https://trello.com/c/GukAlO7p/93-wheelmap-widget-mit-fester-lat-lon-startbar](https://trello.com/c/GukAlO7p/93-wheelmap-widget-mit-fester-lat-lon-startbar)

The fix is not specific too widget mode but applies for the app in general. When the lat & lon are specified in the URL the map should never jump away from that the position on load.