### PR TITLE
Ensure that leaving mapping events tracks correctly

### DIFF
--- a/src/lib/TrackingEventBackend.js
+++ b/src/lib/TrackingEventBackend.js
@@ -32,6 +32,7 @@ export type AppOpenedTrackingEvent = {
 
 export type MappingEventJoinedTrackingEvent = {
   type: 'MappingEventJoined',
+  joinedMappingEventId: string,
   joinedVia: 'url' | 'button',
   query: {
     [key: string]: string,


### PR DESCRIPTION
- Same logic  wether starting via url or button
- Send no events if nothing changes
- Send correct leave event when joining a new mapping
  event
- Send joined id to server