### PR TITLE
Make Og Url Absolute For Place Details Page

### DIFF
--- a/src/app/PlaceDetailsData.js
+++ b/src/app/PlaceDetailsData.js
@@ -226,7 +226,7 @@ const PlaceDetailsData: DataTableEntry<PlaceDetailsProps> = {
     });
   },
 
-  getHead(props) {
+  getHead(props, baseUrl) {
     const { feature, photos, app, categories, equipmentInfo } = props;
     const { textContent, meta } = app.clientSideConfiguration;
 
@@ -268,13 +268,12 @@ const PlaceDetailsData: DataTableEntry<PlaceDetailsProps> = {
           );
         }
 
-        extras.push(
-          <meta
-            content={router.generatePath('placeDetail', { id: getFeatureId(feature) })}
-            property="og:url"
-            key="og:url"
-          />
-        );
+        const placeDetailPath = router.generatePath('placeDetail', {
+          id: getFeatureId(feature),
+        });
+        const ogUrl = baseUrl ? `${baseUrl}${placeDetailPath}` : placeDetailPath;
+
+        extras.push(<meta content={ogUrl} property="og:url" key="og:url" />);
 
         if (placeTitle) {
           extras.push(<meta content={thisPlaceIsOn} property="og:title" key="og:title" />);

--- a/src/app/getInitialProps.js
+++ b/src/app/getInitialProps.js
@@ -62,7 +62,10 @@ export type DataTableEntry<Props> = {
     isServer: boolean
   ) => Promise<Props>,
   getRenderProps?: (props: Props, isServer: boolean) => Props,
-  getHead?: (props: Props & AppProps) => Promise<React$Element<any>> | React$Element<any>,
+  getHead?: (
+    props: Props & AppProps,
+    baseUrl?: string
+  ) => Promise<React$Element<any>> | React$Element<any>,
   storeInitialRouteProps?: (props: Props) => void,
 };
 
@@ -266,12 +269,12 @@ export function storeInitialRouteProps(routeName: string, props: any) {
   return dataItem.storeInitialRouteProps(props);
 }
 
-export function getHead(routeName: string, props: any) {
+export function getHead(routeName: string, props: any, baseUrl?: string) {
   const dataItem = dataTable[routeName];
 
   if (!dataItem || !dataItem.getHead) {
     return null;
   }
 
-  return dataItem.getHead(props);
+  return dataItem.getHead(props, baseUrl);
 }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -392,7 +392,9 @@ export default class App extends BaseApp {
           )}
           {facebook && <FacebookMeta facebook={facebookMetaData} />}
 
-          {routeName != null && <AsyncNextHead head={getHead(routeName, appProps)} />}
+          {routeName != null && (
+            <AsyncNextHead head={getHead(routeName, appProps, appContext.baseUrl)} />
+          )}
           {!skipApplicationBody && (
             <AppContextProvider value={appContext}>
               <PageComponent


### PR DESCRIPTION
This PR fixes https://trello.com/c/iCMqD1Gg/70-p4-opengraph-canonical-url-should-be-absolute-not-relative

The `baseUrl` from the `AppContext` is now passed down to the appropriate methods so that we can prefix the place detail path with it.