### PR TITLE
Fixes to Report Photo Toolbar UI

### DIFF
--- a/src/MainView.js
+++ b/src/MainView.js
@@ -503,7 +503,8 @@ class MainView extends React.Component<Props, State> {
       this.props.isNotFoundVisible ||
       this.props.modalNodeState ||
       this.props.isPhotoUploadCaptchaToolbarVisible ||
-      this.props.isPhotoUploadInstructionsToolbarVisible;
+      this.props.isPhotoUploadInstructionsToolbarVisible ||
+      Boolean(this.props.photoMarkedForReport);
 
     return (
       <FullscreenBackdrop onClick={this.props.onClickFullscreenBackdrop} isActive={isActive} />
@@ -692,7 +693,8 @@ class MainView extends React.Component<Props, State> {
       this.props.isNotFoundVisible ||
       this.props.modalNodeState ||
       this.props.isPhotoUploadCaptchaToolbarVisible ||
-      this.props.isPhotoUploadInstructionsToolbarVisible
+      this.props.isPhotoUploadInstructionsToolbarVisible ||
+      Boolean(this.props.photoMarkedForReport)
     );
   }
 

--- a/src/components/CloseButton.js
+++ b/src/components/CloseButton.js
@@ -8,15 +8,16 @@ import CloseIcon from './icons/actions/Close';
 type Props = {
   className?: string,
   ariaLabel?: ?string,
-  onClick: () => void,
+  onClick: (event: SyntheticMouseEvent<HTMLButtonElement>) => void,
   onFocus?: () => void,
   onBlur?: () => void,
 };
 
 class CloseButton extends React.Component<Props> {
-  onClick = event => {
+  onClick = (event: SyntheticMouseEvent<HTMLButtonElement>) => {
+    // TODO This check might not be needed anymore. onClick is now mandatory
     if (this.props.onClick) {
-      this.props.onClick();
+      this.props.onClick(event);
       return;
     }
     event.preventDefault();
@@ -37,7 +38,7 @@ class CloseButton extends React.Component<Props> {
   }
 }
 
-const StyledCloseButton = styled(CloseButton)`
+export default styled(CloseButton)`
   display: inline-block;
   padding: 16px;
   font-size: 30px;
@@ -56,5 +57,3 @@ const StyledCloseButton = styled(CloseButton)`
     display: block;
   }
 `;
-
-export default StyledCloseButton;

--- a/src/components/NodeToolbar/FeatureClusterPanel.js
+++ b/src/components/NodeToolbar/FeatureClusterPanel.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import FocusTrap from '@sozialhelden/focus-trap-react';
 import sortBy from 'lodash/sortBy';
 
-import { type Feature, placeNameFor } from '../../lib/Feature';
+import { type Feature, placeNameFor, getFeatureId } from '../../lib/Feature';
 import { type EquipmentInfo } from '../../lib/EquipmentInfo';
 import StyledToolbar from '../NodeToolbar/StyledToolbar';
 import ErrorBoundary from '../ErrorBoundary';
@@ -127,7 +127,9 @@ class UnstyledFeatureClusterPanel extends React.Component<Props, State> {
       return placeNameFor(feature.properties, category || parentCategory);
     });
 
-    return sortedFeatures.map((f, i) => <li key={f._id || f.id}>{this.renderClusterEntry(f)}</li>);
+    return sortedFeatures.map(feature => (
+      <li key={getFeatureId(feature)}>{this.renderClusterEntry(feature)}</li>
+    ));
   }
 
   render() {

--- a/src/components/NodeToolbar/Photos/PhotoSection.js
+++ b/src/components/NodeToolbar/Photos/PhotoSection.js
@@ -46,6 +46,8 @@ class PhotoSection extends React.Component<Props, State> {
         sizes: p.thumbnailSizes || p.sizes,
       });
       delete clone.imageId;
+      delete clone.thumbnailSrcSet;
+      delete clone.thumbnailSizes;
       return clone;
     });
 

--- a/src/components/PhotoUpload/ReportPhotoToolbar.js
+++ b/src/components/PhotoUpload/ReportPhotoToolbar.js
@@ -57,6 +57,7 @@ function reportDescription(reportValue: ReportOptions): ?string {
 }
 
 export type Props = {
+  className?: string,
   hidden: boolean,
   photo: PhotoModel | null,
   onClose: () => void,
@@ -67,63 +68,7 @@ type State = {
   selectedValue: ReportOptions | null,
 };
 
-/* Overwrite Style of wrapper Toolbar component  */
-const StyledToolbar = styled(Toolbar)`
-  transition: opacity 0.3s ease-out, transform 0.15s ease-out, width: 0.15s ease-out, height: 0.15s ease-out;
-  display: flex;
-  flex-direction: column;
-  padding: 1rem;
-  border-top: none;
-  border-radius: 3px;
-  z-index: 1000;
-
-  > header {
-    position: sticky;
-    display: flex;
-    flex-direction: column;
-    top: 0;
-    z-index: 1;
-
-    .close-link {
-      position: absolute;
-      right: 0px;
-    }
-
-    img {
-      margin: 0;
-      width: 100%;
-    }
-
-    h3 {
-      margin: 0.75rem 0;
-    }
-  }
-
-  > .radio-group {
-    margin-top: 1em;
-    flex: 1;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-
-  > footer {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    height: 50px;
-
-    label.link-button {
-      text-align: center;
-    }
-  }
-
-  .link-button[disabled] {
-    opacity: 0.8;
-    background-color: ${colors.neutralBackgroundColor};
-  }
-`;
-
-export default class PhotoUploadInstructionsToolbar extends React.Component<Props, State> {
+class ReportPhotoToolbar extends React.Component<Props, State> {
   props: Props;
 
   state: State = {
@@ -168,8 +113,8 @@ export default class PhotoUploadInstructionsToolbar extends React.Component<Prop
     const ariaLabel = t`Reason for reporting image`;
 
     return (
-      <StyledToolbar
-        className="photoupload-instructions-toolbar"
+      <Toolbar
+        className={this.props.className}
         hidden={this.props.hidden}
         isSwipeable={false}
         isModal
@@ -215,7 +160,52 @@ export default class PhotoUploadInstructionsToolbar extends React.Component<Prop
             {t`Send`}
           </button>
         </footer>
-      </StyledToolbar>
+      </Toolbar>
     );
   }
 }
+
+export default styled(ReportPhotoToolbar)`
+  > header {
+    display: flex;
+    flex-direction: column;
+    top: 0;
+    z-index: 1;
+
+    .close-link {
+      position: absolute;
+      right: 0px;
+    }
+
+    img {
+      margin: 0;
+      width: 100%;
+    }
+
+    h3 {
+      margin: 0.75rem 0;
+    }
+  }
+
+  > .radio-group {
+    margin-top: 1em;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  > footer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    height: 50px;
+
+    label.link-button {
+      text-align: center;
+    }
+  }
+
+  .link-button[disabled] {
+    opacity: 0.8;
+    background-color: ${colors.neutralBackgroundColor};
+  }
+`;

--- a/src/components/PhotoUpload/ReportPhotoToolbar.js
+++ b/src/components/PhotoUpload/ReportPhotoToolbar.js
@@ -83,21 +83,15 @@ const StyledToolbar = styled(Toolbar)`
     flex-direction: column;
     top: 0;
     z-index: 1;
-    height: 200px;
 
     .close-link {
       position: absolute;
       right: 0px;
     }
 
-    > div {
-      display: flex;
-    }
-
     img {
       margin: 0;
       width: 100%;
-      object-fit: contain;
     }
 
     h3 {
@@ -181,7 +175,6 @@ export default class PhotoUploadInstructionsToolbar extends React.Component<Prop
         isModal
       >
         <header>
-          {this.renderCloseLink()}
           <div>
             <img src={photo.src} alt={t`To report`} />
           </div>

--- a/src/components/PhotoUpload/ReportPhotoToolbar.js
+++ b/src/components/PhotoUpload/ReportPhotoToolbar.js
@@ -13,6 +13,7 @@ import CustomRadio from '../NodeToolbar/AccessibilityEditor/CustomRadio';
 import StyledRadioGroup from '../NodeToolbar/AccessibilityEditor/StyledRadioGroup';
 
 import type { PhotoModel } from '../NodeToolbar/Photos/PhotoModel';
+import CloseButton from '../CloseButton';
 
 export type ReportOptions = 'wrong-place' | 'outdated' | 'offensive' | 'other';
 
@@ -120,7 +121,8 @@ class ReportPhotoToolbar extends React.Component<Props, State> {
         isModal
       >
         <header>
-          <div>
+          <CloseButton onClick={this.onClose} />
+          <div className="image-container">
             <img src={photo.src} alt={t`To report`} />
           </div>
           <h3>{t`Which problem would you like to report?`}</h3>
@@ -172,14 +174,15 @@ export default styled(ReportPhotoToolbar)`
     top: 0;
     z-index: 1;
 
-    .close-link {
-      position: absolute;
-      right: 0px;
+    .image-container {
+      height: 200px;
     }
 
     img {
       margin: 0;
       width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
 
     h3 {
@@ -202,6 +205,12 @@ export default styled(ReportPhotoToolbar)`
     label.link-button {
       text-align: center;
     }
+  }
+
+  ${CloseButton} {
+    position: absolute;
+    top: 0px;
+    right: 0px;
   }
 
   .link-button[disabled] {

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -371,6 +371,8 @@ const StyledToolbar = styled(Toolbar)`
   max-height: calc(100% - 120px - env(safe-area-inset-top));
 
   &.toolbar-is-modal {
+    z-index: 1000;
+
     @media (max-height: 512px), (max-width: 512px) {
       top: 0px;
       top: constant(safe-area-inset-top);


### PR DESCRIPTION
Fix for ticket: https://trello.com/c/FT7RmbqT/94-foto-melden-geht-nicht-wenn-orte-geclustert

While digging deeper I saw that the report photo toolbar had a couple of issues:

* The `object-fit` css rule did not work correctly with all the other css properties, which is why the layout was broken in the original ticket reason
* The flexbox vertical layout was broken on different versions of iOS: I decided to not layout with flex but instead just statically
* The report photo toolbar was the only toolbar that didn't render like other modal toolbars (blurry backdrop etc.). I fixed this
* Small typing and react error fixes her and there