### PR TITLE
Display correct statistics in front-end

### DIFF
--- a/src/components/MappingEvents/MappingEventToolbar.js
+++ b/src/components/MappingEvents/MappingEventToolbar.js
@@ -179,8 +179,11 @@ const MappingEventToolbar = ({
         <img className="mapping-event-image" src={imageSource} alt="" />
         <div className="mapping-event-description">{mappingEvent.description}</div>
         <Statistics
-          mappedPlacesCount={mappingEvent.statistics.mappedPlacesCount}
-          invitedParticipantCount={mappingEvent.statistics.invitedParticipantCount}
+          mappedPlacesCount={
+            (mappingEvent.statistics.attributeChangedCount || 0) +
+            (mappingEvent.statistics.surveyCompletedCount || 0)
+          }
+          participantCount={mappingEvent.statistics.joinedParticipantCount || 0}
           endDate={endDate}
         />
         <div className="actions">

--- a/src/components/MappingEvents/Statistics.js
+++ b/src/components/MappingEvents/Statistics.js
@@ -10,12 +10,12 @@ import { UserIcon } from '../icons/ui-elements/index';
 
 type Props = {
   mappedPlacesCount: number,
-  invitedParticipantCount: number,
+  participantCount: number,
   endDate: ?Date,
   className?: string,
 };
 
-const Statistics = ({ mappedPlacesCount, invitedParticipantCount, endDate, className }: Props) => {
+const Statistics = ({ mappedPlacesCount, participantCount, endDate, className }: Props) => {
   // translator: Screenreader description for the statistics/numbers part of a mapping event
   const statisticsRegionAriaLabel = t`Mapping Event Numbers`;
   // translator: Description for number of already mapped places in the mapping event
@@ -43,7 +43,7 @@ const Statistics = ({ mappedPlacesCount, invitedParticipantCount, endDate, class
       <div className="statistic">
         <div className="statistic-count">
           <UserIcon />
-          <span>{invitedParticipantCount}</span>
+          <span>{participantCount}</span>
         </div>
         <div className="statistic-description">{inviteesCountAriaLabel}</div>
       </div>

--- a/src/lib/MappingEvent.js
+++ b/src/lib/MappingEvent.js
@@ -6,11 +6,20 @@ import type { IImage } from './Image';
 type MappingEventStatusEnum = 'draft' | 'planned' | 'ongoing' | 'completed' | 'canceled';
 
 interface MappingEventStatistics {
-  fullParticipantCount: number;
-  invitedParticipantCount: number;
-  draftParticipantCount: number;
-  acceptedParticipantCount: number;
-  mappedPlacesCount: number;
+  // deprecated, do not use
+  fullParticipantCount?: number;
+  // deprecated, do not use
+  draftParticipantCount?: number;
+  // deprecated, do not use
+  acceptedParticipantCount?: number;
+  // deprecated, do not use
+  mappedPlacesCount?: number;
+
+  invitedParticipantCount?: number;
+  joinedParticipantCount?: number;
+
+  attributeChangedCount?: number;
+  surveyCompletedCount?: number;
 }
 
 export interface MappingEvent {


### PR DESCRIPTION
Field names for statistics changed since the original implementation, this moves the values
to the correct implementation