### PR TITLE
Background cache reloading

### DIFF
--- a/src/lib/cache/AccessibilityCloudImageCache.js
+++ b/src/lib/cache/AccessibilityCloudImageCache.js
@@ -31,11 +31,7 @@ export default class AccessibilityCloudImageCache extends URLDataCache<Accessibi
     options: { useCache: boolean } = { useCache: true }
   ): Promise<?AccessibilityCloudImages> {
     return this.getData(
-      `${
-        env.public.accessibilityCloud.baseUrl.cached
-      }/images.json?context=${context}&objectId=${objectId}&appToken=${
-        env.public.accessibilityCloud.appToken
-      }`,
+      `${env.public.accessibilityCloud.baseUrl.cached}/images.json?context=${context}&objectId=${objectId}&appToken=${env.public.accessibilityCloud.appToken}`,
       options
     );
   }
@@ -46,11 +42,7 @@ export default class AccessibilityCloudImageCache extends URLDataCache<Accessibi
     captchaSolution: string
   ): Promise<any> {
     const image = images[0];
-    const url = `${
-      env.public.accessibilityCloud.baseUrl.uncached
-    }/image-upload?placeId=${featureId}&captcha=${captchaSolution}&appToken=${
-      env.public.accessibilityCloud.appToken
-    }`;
+    const url = `${env.public.accessibilityCloud.baseUrl.uncached}/image-upload?placeId=${featureId}&captcha=${captchaSolution}&appToken=${env.public.accessibilityCloud.appToken}`;
     const resizedImage = await readAndCompressImage(image, imageResizeConfig);
     const response = await this.constructor.fetch(url, {
       method: 'POST',
@@ -80,11 +72,7 @@ export default class AccessibilityCloudImageCache extends URLDataCache<Accessibi
     const uploadPromise = new Promise((resolve, reject) => {
       this.constructor
         .fetch(
-          `${
-            env.public.accessibilityCloud.baseUrl.uncached
-          }/images/report?imageId=${photoId}&reason=${reason}&appToken=${
-            env.public.accessibilityCloud.appToken
-          }`,
+          `${env.public.accessibilityCloud.baseUrl.uncached}/images/report?imageId=${photoId}&reason=${reason}&appToken=${env.public.accessibilityCloud.appToken}`,
           {
             method: 'POST',
             headers: {
@@ -125,9 +113,7 @@ export default class AccessibilityCloudImageCache extends URLDataCache<Accessibi
         resolve(this.lastCaptcha);
       } else {
         this.lastCaptcha = null;
-        const url = `${
-          env.public.accessibilityCloud.baseUrl.cached
-        }/captcha.svg?${cacheBuster}&appToken=${env.public.accessibilityCloud.appToken}`;
+        const url = `${env.public.accessibilityCloud.baseUrl.cached}/captcha.svg?${cacheBuster}&appToken=${env.public.accessibilityCloud.appToken}`;
         console.log('Requesting new captcha');
         return this.constructor
           .fetch(url)
@@ -189,4 +175,6 @@ export default class AccessibilityCloudImageCache extends URLDataCache<Accessibi
   captchaSolution: string | null = null;
 }
 
-export const accessibilityCloudImageCache = new AccessibilityCloudImageCache();
+export const accessibilityCloudImageCache = new AccessibilityCloudImageCache({
+  ttl: 1000 * 60 * 5, // 5 minutes
+});

--- a/src/lib/cache/AppCache.js
+++ b/src/lib/cache/AppCache.js
@@ -71,5 +71,6 @@ export default class AppCache extends URLDataCache<AppApiData> {
 }
 
 export const appCache = new AppCache({
-  ttl: 1000 * 60 * 5,
+  reloadInBackground: true,
+  maxAllowedCacheAgeBeforeReload: 1000 * 60 * 5, // 5 minutes
 });

--- a/src/lib/cache/CategoryLookupTablesCache.js
+++ b/src/lib/cache/CategoryLookupTablesCache.js
@@ -8,13 +8,28 @@ import ACCategoryCache from './ACCategoryCache';
 import WheelmapCategoryCache from './WheelmapCategoryCache';
 import WheelmapNodeTypeCache from './WheelmapNodeTypeCache';
 
+export type CategoryLookupTablesCacheOptions = {
+  reloadInBackground: boolean,
+  // time in milliseconds
+  maxAllowedCacheAgeBeforeReload: number,
+};
+
+const defaultLocales = ['de', 'en'];
+
 export default class CategoryLookupTablesCache {
   lookupTablesCache: TTLCache<string, Promise<RawCategoryLists>>;
   acCategoryCache: ?ACCategoryCache;
   wheelmapCategoryCache: ?WheelmapCategoryCache;
   wheelmapNodeTypeCache: ?WheelmapNodeTypeCache;
+  options: CategoryLookupTablesCacheOptions;
 
-  constructor(options: $Shape<TTLCacheOptions>) {
+  constructor(options: $Shape<TTLCacheOptions & CategoryLookupTablesCacheOptions>) {
+    this.options = {
+      maxAllowedCacheAgeBeforeReload: 15000,
+      reloadInBackground: true,
+      ...options,
+    };
+
     this.lookupTablesCache = new TTLCache<string, Promise<RawCategoryLists>>();
 
     if (env.public.accessibilityCloud.appToken && env.public.accessibilityCloud.baseUrl.cached) {
@@ -38,6 +53,12 @@ export default class CategoryLookupTablesCache {
         baseUrl: config.wheelmapApiBaseUrl,
       });
     }
+
+    // preload some of the locales already
+    for (const locale of defaultLocales) {
+      console.log('Preloading categories for', locale);
+      this.getRawCategoryLists({ locale });
+    }
   }
 
   getRawCategoryLists(options: {
@@ -48,6 +69,10 @@ export default class CategoryLookupTablesCache {
 
     const storedPromise = this.lookupTablesCache.get(countryCode);
     if (storedPromise) {
+      if (this.options.reloadInBackground) {
+        this.reloadInBackground(countryCode);
+      }
+
       return storedPromise;
     }
 
@@ -60,8 +85,54 @@ export default class CategoryLookupTablesCache {
     const countryCode = localeString.substr(0, 2);
     this.lookupTablesCache.set(countryCode, Promise.resolve(rawCategoryLists));
   }
+
+  /**
+   * Updates a valid entry in the ttl cache. Leaves resolved promise in the cache as
+   * long as possible to prevent slow responses in between.
+   *
+   * This introduces a potential resource waste/timing issue
+   *  T0: req1 - cache still valid, background reloading triggers
+   *  T1: req2 - cache invalid, new request started, not reusing the promise of req1
+   *  T2: res2 - updates cache
+   *  T3: res1 - updates cache again (with potentially older result)
+   *
+   * A solution could be storing the reload promise with the ttl-cache entry and using it
+   * when the ttl entry is expired. This would increase the complexity too much for
+   * an edge case that no one will care about.
+   */
+  reloadInBackground(countryCode: string) {
+    const now = Date.now();
+    const cacheEntry = this.lookupTablesCache.getCacheItem(countryCode);
+
+    if (!cacheEntry) {
+      // something went wrong, this should not happen
+      return;
+    }
+
+    if (cacheEntry.isReloading) {
+      return;
+    }
+
+    const elapsed = now - cacheEntry.storageTimestamp;
+
+    if (elapsed > this.options.maxAllowedCacheAgeBeforeReload) {
+      cacheEntry.isReloading = true;
+      // download data
+      const promise = this.getRawCategoryLists({ locale: countryCode });
+      // only update the cache when the promise resolves
+      promise
+        .then(() => {
+          cacheEntry.isReloading = false;
+          this.lookupTablesCache.set(countryCode, promise);
+        })
+        .catch(e => {
+          cacheEntry.isReloading = false;
+        });
+    }
+  }
 }
 
 export const categoriesCache = new CategoryLookupTablesCache({
-  ttl: 1000 * 60 * 60,
+  reloadInBackground: true,
+  maxAllowedCacheAgeBeforeReload: 1000 * 60 * 60, // 1 hour
 });

--- a/src/lib/cache/MappingEventsCache.js
+++ b/src/lib/cache/MappingEventsCache.js
@@ -13,9 +13,7 @@ export default class MappingEventsCache extends URLDataCache<MappingEventsData> 
   baseUrl = env.public.accessibilityCloud.baseUrl.cached;
 
   async getMappingEvents(app: App): Promise<MappingEvent[]> {
-    const url = `${this.baseUrl}/mapping-events.json?appToken=${
-      app.tokenString
-    }&includeRelated=images`;
+    const url = `${this.baseUrl}/mapping-events.json?appToken=${app.tokenString}&includeRelated=images`;
     const data = await this.getData(url);
     return data.results.map(mappingEvent => ({
       ...mappingEvent,
@@ -32,5 +30,6 @@ export default class MappingEventsCache extends URLDataCache<MappingEventsData> 
 }
 
 export const mappingEventsCache = new MappingEventsCache({
-  ttl: 1000 * 60 * 2, // 2 minutes
+  reloadInBackground: true,
+  maxAllowedCacheAgeBeforeReload: 1000 * 30, // 30 seconds
 });

--- a/src/lib/cache/TTLCache.js
+++ b/src/lib/cache/TTLCache.js
@@ -2,6 +2,8 @@
 export interface TTLCacheItem<T> {
   value: T;
   expire: number;
+  storageTimestamp: number;
+  isReloading: boolean;
 }
 
 export type TTLCacheOptions = {
@@ -41,6 +43,8 @@ class TTLCache<K, V> {
     const item: TTLCacheItem<V> = {
       value,
       expire,
+      isReloading: false,
+      storageTimestamp: now,
     };
 
     while (this.cache.size >= this.options.max) {
@@ -73,6 +77,17 @@ class TTLCache<K, V> {
     }
 
     return value;
+  }
+
+  getCacheItem(key: K): ?TTLCacheItem<V> {
+    const item = this.cache.get(key);
+
+    // Test against null and undefined
+    if (item == null) {
+      return null;
+    }
+
+    return item;
   }
 
   has(key: K): boolean {

--- a/src/lib/cache/URLDataCache.js
+++ b/src/lib/cache/URLDataCache.js
@@ -6,13 +6,26 @@ import EJSON from 'ejson';
 import ResponseError from '../ResponseError';
 import TTLCache, { type TTLCacheOptions } from './TTLCache';
 
+export type URLDataCacheOptions = {
+  reloadInBackground: boolean,
+  // time in milliseconds
+  maxAllowedCacheAgeBeforeReload: number,
+};
+
 // Provides a WhatWG-fetch-like API to make HTTP requests.
 // Caches response promises and returns an old promise if one is existing for the same URL.
 
 export default class URLDataCache<T> {
   cache: TTLCache<string, Promise<T>>;
+  options: URLDataCacheOptions;
 
-  constructor(options?: $Shape<TTLCacheOptions>) {
+  constructor(options?: $Shape<TTLCacheOptions & URLDataCacheOptions>) {
+    this.options = {
+      maxAllowedCacheAgeBeforeReload: 15000,
+      reloadInBackground: false,
+      ...options,
+    };
+
     this.cache = new TTLCache<string, Promise<T>>(options);
   }
 
@@ -38,16 +51,63 @@ export default class URLDataCache<T> {
     let promise = this.cache.get(url);
 
     if (promise) {
+      if ((!options || options.useCache) && this.options.reloadInBackground) {
+        this.reloadInBackground(url);
+      }
       return promise;
     }
 
     promise = this.fetch(url);
-
     if (!options || options.useCache) {
       this.cache.set(url, promise);
     }
 
     return promise;
+  }
+
+  /**
+   * Updates a valid entry in the ttl cache. Leaves resolved promise in the cache as
+   * long as possible to prevent slow responses in between.
+   *
+   * This introduces a potential resource waste/timing issue
+   *  T0: req1 - cache still valid, background reloading triggers
+   *  T1: req2 - cache invalid, new request started, not reusing the promise of req1
+   *  T2: res2 - updates cache
+   *  T3: res1 - updates cache again (with potentially older result)
+   *
+   * A solution could be storing the reload promise with the ttl-cache entry and using it
+   * when the ttl entry is expired. This would increase the complexity too much for
+   * an edge case that no one will care about.
+   */
+  reloadInBackground(url: string) {
+    const now = Date.now();
+    const cacheEntry = this.cache.getCacheItem(url);
+
+    if (!cacheEntry) {
+      // something went wrong, this should not happen
+      return;
+    }
+
+    if (cacheEntry.isReloading) {
+      return;
+    }
+
+    const elapsed = now - cacheEntry.storageTimestamp;
+
+    if (elapsed > this.options.maxAllowedCacheAgeBeforeReload) {
+      cacheEntry.isReloading = true;
+      // download data
+      const promise = this.fetch(url);
+      // only update the cache when the promise resolves
+      promise
+        .then(() => {
+          cacheEntry.isReloading = false;
+          this.cache.set(url, promise);
+        })
+        .catch(e => {
+          cacheEntry.isReloading = false;
+        });
+    }
   }
 
   inject(url: string, result: T) {

--- a/src/lib/cache/WheelmapFeaturePhotosCache.js
+++ b/src/lib/cache/WheelmapFeaturePhotosCache.js
@@ -16,4 +16,6 @@ export default class WheelmapFeaturePhotosCache extends URLDataCache<?WheelmapFe
   }
 }
 
-export const wheelmapFeaturePhotosCache = new WheelmapFeaturePhotosCache();
+export const wheelmapFeaturePhotosCache = new WheelmapFeaturePhotosCache({
+  ttl: 1000 * 60 * 5, // 5 minutes
+});


### PR DESCRIPTION
Added ability to url-data & category lookup table cache to
deliver data from cache while reloading new data in the background.

This leads to faster response time as the relevant data is either
already prefetched by a previous request or will be for the next
request.