### PR TITLE
Aligned mapping events filter

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -413,6 +413,10 @@ export default class Map extends React.Component<Props, State> {
 
     this.navigate(this.state, this.props, prevProps);
 
+    if (prevProps.mappingEvents !== this.props.mappingEvents) {
+      this.setupMappingEvents();
+    }
+
     // Sort is mutable. Create a new array and sort this one instead.
     const accessibilityFilterChanged = !isEqual(
       [...this.props.accessibilityFilter].sort(),
@@ -602,6 +606,12 @@ export default class Map extends React.Component<Props, State> {
   setupMappingEvents() {
     const map = this.map;
     const mappingEvents = this.props.mappingEvents;
+
+    if (map && this.mappingEventsLayer) {
+      map.removeLayer(this.mappingEventsLayer);
+      this.mappingEventsLayer = null;
+    }
+
     if (!map || !mappingEvents) {
       return;
     }

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -50,13 +50,12 @@ import colors, { interpolateWheelchairAccessibility } from '../../lib/colors';
 import useImperialUnits from '../../lib/useImperialUnits';
 import { tileLoadingStatus } from './trackTileLoadingState';
 import { type Cluster } from './Cluster';
-import { type MappingEvents, isMappingEventVisible } from '../../lib/MappingEvent';
+import { type MappingEvents } from '../../lib/MappingEvent';
 import A11yMarkerIcon from './A11yMarkerIcon';
 import MappingEventMarkerIcon from './MappingEventMarkerIcon';
 
 import './Leaflet.css';
 import './Map.css';
-import MappingEventHaloMarkerIcon from './MappingEventHaloMarkerIcon';
 import { hrefForMappingEvent } from '../../lib/MappingEvent';
 
 L.Map.addInitHook('addHandler', 'gestureHandling', GestureHandling);
@@ -611,32 +610,30 @@ export default class Map extends React.Component<Props, State> {
     this.mappingEventsLayer = mappingEventsLayer;
     map.addLayer(mappingEventsLayer);
 
-    mappingEvents
-      .filter(event => isMappingEventVisible(event) || event._id === this.props.featureId)
-      .forEach(event => {
-        const eventFeature = event.meetingPoint;
+    mappingEvents.forEach(event => {
+      const eventFeature = event.meetingPoint;
 
-        if (!eventFeature) {
-          return;
-        }
+      if (!eventFeature) {
+        return;
+      }
 
-        const eventLat = eventFeature.geometry.coordinates[1];
-        const eventLon = eventFeature.geometry.coordinates[0];
+      const eventLat = eventFeature.geometry.coordinates[1];
+      const eventLon = eventFeature.geometry.coordinates[0];
 
-        const eventMarker = new HighlightableMarker(
-          new L.LatLng(eventLat, eventLon),
-          MappingEventMarkerIcon,
-          {
-            eventName: event.name,
-            href: hrefForMappingEvent(event),
-            onClick: () => this.props.onMappingEventClick(event._id),
-          },
-          event._id,
-          -1000
-        );
+      const eventMarker = new HighlightableMarker(
+        new L.LatLng(eventLat, eventLon),
+        MappingEventMarkerIcon,
+        {
+          eventName: event.name,
+          href: hrefForMappingEvent(event),
+          onClick: () => this.props.onMappingEventClick(event._id),
+        },
+        event._id,
+        -1000
+      );
 
-        mappingEventsLayer.addLayer(eventMarker);
-      });
+      mappingEventsLayer.addLayer(eventMarker);
+    });
   }
 
   removeLayersNotVisibleInZoomLevel() {

--- a/src/components/MappingEvents/MappingEventsToolbar.js
+++ b/src/components/MappingEvents/MappingEventsToolbar.js
@@ -10,7 +10,6 @@ import Link, { RouteConsumer } from '../Link/Link';
 import CloseButton from './CloseButton';
 import { type MappingEvents } from '../../lib/MappingEvent';
 import { type App } from '../../lib/App';
-import { isMappingEventVisible } from '../../lib/MappingEvent';
 
 type MappingEventsToolbarProps = {
   app: App,
@@ -36,9 +35,7 @@ const MappingEventsToolbar = ({
   // translator: Tagline describing the purpose of mapping events
   const mappingEventsTagLine = t`Meet the community and map the accessibility of places around you!`;
 
-  const listedMappingEvents = mappingEvents
-    .filter(isMappingEventVisible)
-    .filter(event => event.appId === app._id);
+  const listedMappingEvents = mappingEvents;
 
   return (
     <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>


### PR DESCRIPTION
- Moved filtering into app
    - removed from toolbar/map
   - Always filter by app id & isVisible
   - Removed odd requery-logic from App (is already happening higher up)
   - Display current selected mapping event on map when opened by url
    (e.g. preview mode from accessibility.apps)

Update mapping events on map
   - Map markers where never updated before, now the markers
    are updated whenever the filter or available events
    change