### PR TITLE
Add tag name to request body for refresh endpoint

### DIFF
--- a/src/lib/fetchers/callBackendToUpdateInhouseDb.ts
+++ b/src/lib/fetchers/callBackendToUpdateInhouseDb.ts
@@ -4,10 +4,12 @@ export async function callBackendToUpdateInhouseDb({
   baseUrl,
   osmId,
   osmType,
+  tagName,
 }: {
   baseUrl: string;
   osmId: string;
   osmType: string;
+  tagName: string;
 }) {
   log.log('writeChangesToInhouseDb', osmType, osmId)
   const osmIdAsNumber = osmId.replace(/\D/g, '')
@@ -18,6 +20,7 @@ export async function callBackendToUpdateInhouseDb({
     },
     method: 'POST',
     mode: 'cors',
+    body: tagName
   })
 
   if (!response.ok) {

--- a/src/lib/fetchers/osm-api/makeChangeRequestToOsmApi.ts
+++ b/src/lib/fetchers/osm-api/makeChangeRequestToOsmApi.ts
@@ -1,7 +1,6 @@
 import React from 'react'
 import { SWRResponse } from 'swr'
 import { log } from '../../util/logger'
-import { ChangesetState } from './ChangesetState'
 import { callBackendToUpdateInhouseDb } from '../callBackendToUpdateInhouseDb'
 import useOSMAPI from './useOSMAPI'
 
@@ -153,7 +152,7 @@ export default function useSubmitNewValueCallback({
       changesetComplete = true
 
       await callBackendToUpdateInhouseDb({
-        baseUrl: inhouseBaseUrl, osmType, osmId,
+        baseUrl: inhouseBaseUrl, osmType, osmId, tagName
       })
 
       handleSuccess()


### PR DESCRIPTION
Added tag name to request body to make it work with the changes in the osm api. Only works with the corresponding branch (same name) in the osm-api repo.