### PR TITLE
Fix Keyboard Navigation Bug in Editor Modals

### DIFF
--- a/src/modules/edit/components/AddDescriptionButton.tsx
+++ b/src/modules/edit/components/AddDescriptionButton.tsx
@@ -1,9 +1,9 @@
 import { Pencil } from "lucide-react";
 import React, { type ReactNode, useContext, useState } from "react";
-import { AutoEditor } from "~/modules/edit/components/AutoEditor";
 
 import { SecondaryButton } from "~/components/button/SecondaryButton";
 import { FeaturePanelContext } from "~/needs-refactoring/components/CombinedFeaturePanel/FeaturePanelContext";
+import DescriptionEditor from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/DescriptionEditor";
 
 interface Props {
   tagKey: string;
@@ -28,11 +28,12 @@ export function AddDescriptionButton({ tagKey, children }: Props) {
       </SecondaryButton>
 
       {isDialogOpen && feature && (
-        <AutoEditor
+        <DescriptionEditor
+          isDialogOpen={isDialogOpen}
+          setIsDialogOpen={setIsDialogOpen}
           feature={feature}
           tagKey={tagKey}
           addNewLanguage={true}
-          onClose={() => setIsDialogOpen(false)}
         />
       )}
     </>

--- a/src/modules/edit/components/AutoEditor.tsx
+++ b/src/modules/edit/components/AutoEditor.tsx
@@ -21,8 +21,8 @@ import { normalizeAndExtractLanguageTagsIfPresent } from "~/needs-refactoring/li
 import { log } from "~/needs-refactoring/lib/util/logger";
 import type { BaseEditorProps } from "./BaseEditor";
 import { StringFieldEditor } from "./StringFieldEditor";
-import { ToiletsWheelchairEditor } from "./ToiletsWheelchairEditor";
-import { WheelchairEditor } from "./WheelchairEditor";
+import { ToiletsWheelchairEditorOld } from "./ToiletsWheelchairEditorOld";
+import { WheelchairEditorOld } from "./WheelchairEditorOld";
 
 function getEditorForKey(key: string): React.FC<BaseEditorProps> | undefined {
   switch (true) {
@@ -30,10 +30,10 @@ function getEditorForKey(key: string): React.FC<BaseEditorProps> | undefined {
       return StringFieldEditor;
 
     case key === "wheelchair":
-      return WheelchairEditor;
+      return WheelchairEditorOld;
 
     case key === "toilets:wheelchair":
-      return ToiletsWheelchairEditor;
+      return ToiletsWheelchairEditorOld;
 
     default:
       return undefined;

--- a/src/modules/edit/components/FeatureDetails.tsx
+++ b/src/modules/edit/components/FeatureDetails.tsx
@@ -145,6 +145,7 @@ const FeatureDetails = ({
                 <WheelchairSection
                   key="osm_wheelchair"
                   tags={osmWheelchairInfo}
+                  feature={feature}
                 />
               </Section>
             )}
@@ -155,6 +156,7 @@ const FeatureDetails = ({
                   tags={osmToiletInfo}
                   nextToilet={nextAccessibleToilet}
                   isLoading={isLoadingNextToilet}
+                  feature={feature}
                 />
               </Section>
             )}

--- a/src/modules/edit/components/ToiletRadioCards.tsx
+++ b/src/modules/edit/components/ToiletRadioCards.tsx
@@ -21,6 +21,7 @@ const ToiletRadioCards = ({ onSelect, defaultValue }: Props) => {
         <RadioCards.Item
           value="yes"
           style={{ backgroundColor: "var(--green-4)" }}
+          data-testid="yes-item"
         >
           <Flex direction="column" width="100%">
             <Flex direction="row" gap="2">
@@ -37,7 +38,11 @@ const ToiletRadioCards = ({ onSelect, defaultValue }: Props) => {
           </Flex>
         </RadioCards.Item>
 
-        <RadioCards.Item value="no" style={{ backgroundColor: "var(--red-8)" }}>
+        <RadioCards.Item
+          value="no"
+          style={{ backgroundColor: "var(--red-8)" }}
+          data-testid="no-item"
+        >
           <Flex direction="column" width="100%" justify="center">
             <Flex direction="row" gap="2">
               <ToiletStatusNotAccessible />

--- a/src/modules/edit/components/ToiletRadioCards.tsx
+++ b/src/modules/edit/components/ToiletRadioCards.tsx
@@ -7,7 +7,7 @@ import type { YesNoUnknown } from "~/needs-refactoring/lib/model/ac/Feature";
 
 type Props = {
   onSelect: (value: YesNoUnknown) => void;
-  defaultValue: string;
+  defaultValue: string | undefined;
 };
 
 const ToiletRadioCards = ({ onSelect, defaultValue }: Props) => {

--- a/src/modules/edit/components/ToiletsSection.tsx
+++ b/src/modules/edit/components/ToiletsSection.tsx
@@ -6,7 +6,7 @@ import type { NextAccessibleToilet } from "~/modules/edit/hooks/useNextAccessibl
 import type { TagOrTagGroup } from "~/modules/edit/hooks/useOsmTags";
 import { getValueLabel } from "~/modules/edit/utils/getValueLabel";
 import { useTranslations } from "~/modules/i18n/hooks/useTranslations";
-import { EditDropdownMenu } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu";
+import EditDropdownMenu from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu";
 import NextToiletDirections from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/NextToiletDirections";
 import StyledTag from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/StyledTag";
 import StyledMarkdown from "~/needs-refactoring/components/shared/StyledMarkdown";

--- a/src/modules/edit/components/ToiletsSection.tsx
+++ b/src/modules/edit/components/ToiletsSection.tsx
@@ -10,7 +10,7 @@ import { EditDropdownMenu } from "~/needs-refactoring/components/CombinedFeature
 import NextToiletDirections from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/NextToiletDirections";
 import StyledTag from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/StyledTag";
 import StyledMarkdown from "~/needs-refactoring/components/shared/StyledMarkdown";
-import ToiletsWheelchairEditorNew from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/ToiletsWheelchairEditorNew";
+import ToiletsWheelchairEditor from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/ToiletsWheelchairEditor";
 import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
 
 type Props = {
@@ -53,7 +53,7 @@ const ToiletsSection = ({ nextToilet, isLoading, tags, feature }: Props) => {
                 )}
               </StyledMarkdown>
             </Text>
-            <ToiletsWheelchairEditorNew
+            <ToiletsWheelchairEditor
               feature={feature}
               tagKey={wheelchairInfo.key}
               tagValue={String(wheelchairInfo.value)}

--- a/src/modules/edit/components/ToiletsSection.tsx
+++ b/src/modules/edit/components/ToiletsSection.tsx
@@ -6,19 +6,21 @@ import type { NextAccessibleToilet } from "~/modules/edit/hooks/useNextAccessibl
 import type { TagOrTagGroup } from "~/modules/edit/hooks/useOsmTags";
 import { getValueLabel } from "~/modules/edit/utils/getValueLabel";
 import { useTranslations } from "~/modules/i18n/hooks/useTranslations";
-import { EditButton } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditButton";
-import { EditDropdownMenu } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropDownMenu";
+import { EditDropdownMenu } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu";
 import NextToiletDirections from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/NextToiletDirections";
 import StyledTag from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/StyledTag";
 import StyledMarkdown from "~/needs-refactoring/components/shared/StyledMarkdown";
+import ToiletsWheelchairEditorNew from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/ToiletsWheelchairEditorNew";
+import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
 
 type Props = {
   nextToilet?: NextAccessibleToilet;
   isLoading?: boolean;
   tags?: TagOrTagGroup;
+  feature: AnyFeature;
 };
 
-const ToiletsSection = ({ nextToilet, isLoading, tags }: Props) => {
+const ToiletsSection = ({ nextToilet, isLoading, tags, feature }: Props) => {
   const wheelchairInfo = tags?.children.find(
     (tag) => tag.key === "toilets:wheelchair",
   );
@@ -51,7 +53,11 @@ const ToiletsSection = ({ nextToilet, isLoading, tags }: Props) => {
                 )}
               </StyledMarkdown>
             </Text>
-            <EditButton addNewLanguage={false} tagKey={wheelchairInfo.key} />
+            <ToiletsWheelchairEditorNew
+              feature={feature}
+              tagKey={wheelchairInfo.key}
+              tagValue={String(wheelchairInfo.value)}
+            />
           </Flex>
         </Grid>
       )}
@@ -81,7 +87,11 @@ const ToiletsSection = ({ nextToilet, isLoading, tags }: Props) => {
               </Text>
             </Box>
             <Box>
-              <EditDropdownMenu tagKey={description.key} />
+              <EditDropdownMenu
+                tagKey={description.key}
+                tagValue={description.value}
+                feature={feature}
+              />
             </Box>
           </Grid>
         ) : (

--- a/src/modules/edit/components/ToiletsWheelchairEditorOld.tsx
+++ b/src/modules/edit/components/ToiletsWheelchairEditorOld.tsx
@@ -11,7 +11,7 @@ import type { YesNoUnknown } from "~/needs-refactoring/lib/model/ac/Feature";
 import { isOrHasAccessibleToilet } from "~/needs-refactoring/lib/model/accessibility/isOrHasAccessibleToilet";
 import type { BaseEditorProps } from "./BaseEditor";
 
-export const ToiletsWheelchairEditor: React.FC<BaseEditorProps> = ({
+export const ToiletsWheelchairEditorOld: React.FC<BaseEditorProps> = ({
   feature,
   onChange,
   onSubmit,

--- a/src/modules/edit/components/WheelchairEditorOld.tsx
+++ b/src/modules/edit/components/WheelchairEditorOld.tsx
@@ -12,7 +12,7 @@ import type { YesNoLimitedUnknown } from "~/needs-refactoring/lib/model/ac/Featu
 import { isWheelchairAccessible } from "~/needs-refactoring/lib/model/accessibility/isWheelchairAccessible";
 import type { BaseEditorProps } from "./BaseEditor";
 
-export const WheelchairEditor: React.FC<BaseEditorProps> = ({
+export const WheelchairEditorOld: React.FC<BaseEditorProps> = ({
   feature,
   onChange,
   onSubmit,

--- a/src/modules/edit/components/WheelchairRadioCards.tsx
+++ b/src/modules/edit/components/WheelchairRadioCards.tsx
@@ -22,6 +22,7 @@ const WheelchairRadioCards = ({ category, onSelect, defaultValue }: Props) => {
         <RadioCards.Item
           value="yes"
           style={{ backgroundColor: "var(--green-4)" }}
+          data-testid="yes-item"
         >
           <Flex direction="column" width="100%">
             <Flex direction="row" gap="2">
@@ -46,6 +47,7 @@ const WheelchairRadioCards = ({ category, onSelect, defaultValue }: Props) => {
         <RadioCards.Item
           value="limited"
           style={{ backgroundColor: "var(--orange-7)" }}
+          data-testid="limited-item"
         >
           <Flex direction="column" width="100%">
             <Flex direction="row" gap="2">
@@ -70,6 +72,7 @@ const WheelchairRadioCards = ({ category, onSelect, defaultValue }: Props) => {
         <RadioCards.Item
           value="no"
           style={{ backgroundColor: "var(--ruby-7)" }}
+          data-testid="no-item"
         >
           <Flex direction="column" width="100%" justify="center">
             <Flex direction="row" gap="2">

--- a/src/modules/edit/components/WheelchairRadioCards.tsx
+++ b/src/modules/edit/components/WheelchairRadioCards.tsx
@@ -8,7 +8,7 @@ import type { YesNoLimitedUnknown } from "~/needs-refactoring/lib/model/ac/Featu
 type Props = {
   category: CategoryProperties;
   onSelect: (value: YesNoLimitedUnknown) => void;
-  defaultValue: string;
+  defaultValue: string | undefined;
 };
 
 const WheelchairRadioCards = ({ category, onSelect, defaultValue }: Props) => {

--- a/src/modules/edit/components/WheelchairSection.tsx
+++ b/src/modules/edit/components/WheelchairSection.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from "~/modules/i18n/hooks/useTranslations";
 import StyledMarkdown from "~/needs-refactoring/components/shared/StyledMarkdown";
 
 import { t } from "@transifex/native";
-import WheelchairEditorNew from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/WheelchairEditorNew";
+import WheelchairEditor from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/WheelchairEditor";
 import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
 import EditDropdownMenu from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu";
 
@@ -45,7 +45,7 @@ const WheelchairSection = ({ tags, feature }: Props) => {
                 {String(wheelchairInfoText)}
               </StyledMarkdown>
             </Text>
-            <WheelchairEditorNew
+            <WheelchairEditor
               tagKey={wheelchairInfo.key}
               tagValue={String(wheelchairInfo.value)}
               feature={feature}

--- a/src/modules/edit/components/WheelchairSection.tsx
+++ b/src/modules/edit/components/WheelchairSection.tsx
@@ -3,17 +3,20 @@ import type React from "react";
 import { AddDescriptionButton } from "~/modules/edit/components/AddDescriptionButton";
 import type { TagOrTagGroup } from "~/modules/edit/hooks/useOsmTags";
 import { useTranslations } from "~/modules/i18n/hooks/useTranslations";
-import { EditButton } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditButton";
-import { EditDropdownMenu } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropDownMenu";
+
 import StyledMarkdown from "~/needs-refactoring/components/shared/StyledMarkdown";
 
 import { t } from "@transifex/native";
+import WheelchairEditorNew from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/WheelchairEditorNew";
+import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
+import EditDropdownMenu from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu";
 
 type Props = {
   tags: TagOrTagGroup;
+  feature: AnyFeature;
 };
 
-const WheelchairSection = ({ tags }: Props) => {
+const WheelchairSection = ({ tags, feature }: Props) => {
   const wheelchairInfo = tags.children.find((tag) => tag.key === "wheelchair");
 
   const wheelchairDescription = tags.children.find((tag) =>
@@ -42,7 +45,11 @@ const WheelchairSection = ({ tags }: Props) => {
                 {String(wheelchairInfoText)}
               </StyledMarkdown>
             </Text>
-            <EditButton addNewLanguage={false} tagKey={wheelchairInfo.key} />
+            <WheelchairEditorNew
+              tagKey={wheelchairInfo.key}
+              tagValue={String(wheelchairInfo.value)}
+              feature={feature}
+            />
           </Flex>
         </Grid>
       )}
@@ -56,7 +63,11 @@ const WheelchairSection = ({ tags }: Props) => {
             </Text>
           </Box>
           <Box>
-            <EditDropdownMenu tagKey={wheelchairDescription.key} />
+            <EditDropdownMenu
+              tagKey={wheelchairDescription.key}
+              tagValue={wheelchairDescription.value}
+              feature={feature}
+            />
           </Box>
         </Grid>
       ) : (

--- a/src/modules/edit/tests/edit-toilet-accessibility.e2e-spec.ts
+++ b/src/modules/edit/tests/edit-toilet-accessibility.e2e-spec.ts
@@ -23,18 +23,18 @@ test.describe("Edit toilet accessibility", () => {
   //   //TODO
   // });
 
-  test("radios are clickable & confirm button changes to send after input changes", async ({
+  test("confirm button changes to send after input changes", async ({
     page,
   }) => {
     await expect(getButton(dialog, "Confirm")).toBeVisible();
 
-    const yesRadio = page.locator("form svg").first();
-    const noRadio = page.locator("form svg").nth(2);
+    const yesItem = page.locator(`[data-testid="yes-item"]`);
+    const noItem = page.locator(`[data-testid="no-item"]`);
 
-    await expect(yesRadio).toBeVisible();
-    await expect(noRadio).toBeVisible();
+    await expect(yesItem).toBeVisible();
+    await expect(noItem).toBeVisible();
 
-    await noRadio.click();
+    await noItem.click();
     await expect(getButton(dialog, "Send")).toBeVisible();
   });
 

--- a/src/modules/edit/tests/edit-wheelchair-accessibility.e2e-spec.ts
+++ b/src/modules/edit/tests/edit-wheelchair-accessibility.e2e-spec.ts
@@ -27,15 +27,15 @@ test.describe("Edit wheelchair accessibility", () => {
     page,
   }) => {
     await expect(dialog.getByRole("button", { name: "Confirm" })).toBeVisible();
-    const yesRadio = page.locator("form svg").first();
-    const limitedRadio = page.locator("form svg").nth(2);
-    const noRadio = page.locator("form svg").nth(3);
+    const yesItem = page.locator(`[data-testid="yes-item"]`);
+    const limitedItem = page.locator(`[data-testid="limited-item"]`);
+    const noItem = page.locator(`[data-testid="no-item"]`);
 
-    await expect(yesRadio).toBeVisible();
-    await expect(limitedRadio).toBeVisible();
-    await expect(noRadio).toBeVisible();
+    await expect(yesItem).toBeVisible();
+    await expect(limitedItem).toBeVisible();
+    await expect(noItem).toBeVisible();
 
-    await noRadio.click();
+    await noItem.click();
     await expect(getButton(dialog, "Send")).toBeVisible();
   });
 

--- a/src/modules/edit/utils/attachPropsRecursively.ts
+++ b/src/modules/edit/utils/attachPropsRecursively.ts
@@ -17,6 +17,7 @@ export function attachTagPropsRecursively(
   const matchedKey = Object.keys(valueRenderFunctions).find(
     (renderFunctionKey) => key.match(renderFunctionKey),
   );
+  tagOrGroup.value = singleValue;
   tagOrGroup.tagProps = getOSMTagProps({
     key,
     matchedKey,

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/DescriptionEditor.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/DescriptionEditor.tsx
@@ -1,0 +1,222 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
+import {
+  getAvailableLangTags,
+  normalizeAndExtractLanguageTagsIfPresent,
+} from "~/needs-refactoring/lib/util/TagKeyUtils";
+import { t } from "@transifex/native";
+import {
+  Callout,
+  Dialog,
+  Flex,
+  Text,
+  TextArea,
+  VisuallyHidden,
+} from "@radix-ui/themes";
+import FeatureNameHeader from "~/needs-refactoring/components/CombinedFeaturePanel/components/FeatureNameHeader";
+import { Info } from "lucide-react";
+import SearchableSelect from "~/needs-refactoring/components/shared/SearchableSelect";
+import { supportedLanguageTagsOptions } from "~/modules/i18n/i18n";
+import { SecondaryButton } from "~/components/button/SecondaryButton";
+import { PrimaryButton } from "~/components/button/PrimaryButton";
+import useSubmit from "~/needs-refactoring/components/CombinedFeaturePanel/useSubmit";
+
+type Props = {
+  tagKey: string;
+  tagValue?: string | undefined;
+  feature: AnyFeature;
+  addNewLanguage: boolean;
+  isDialogOpen: boolean;
+  setIsDialogOpen: (isDialogOpen: boolean) => void;
+};
+
+const DescriptionEditor = ({
+  tagKey,
+  tagValue,
+  feature,
+  addNewLanguage,
+  isDialogOpen,
+  setIsDialogOpen,
+}: Props) => {
+  const { normalizedOSMTagKey: tagKeyWithoutLangTag } =
+    normalizeAndExtractLanguageTagsIfPresent(tagKey);
+
+  const descriptionKeys = Object.keys(feature.properties ?? {}).filter((key) =>
+    key.startsWith(tagKeyWithoutLangTag),
+  );
+  const availableLangTags = getAvailableLangTags(
+    descriptionKeys,
+    tagKeyWithoutLangTag.split(":").length,
+  );
+
+  const [currentTagValue, setCurrentTagValue] = useState(tagValue);
+  const [newTagValue, setNewTagValue] = useState(tagValue);
+  const [textAreaValue, setTextAreaValue] = useState("");
+  const [selectedLanguage, setSelectedLanguage] = useState("");
+  const [hasDataToSubmit, setHasDataToSubmit] = useState(true);
+  const [hasValueChanged, setHasValueChanged] = useState(false);
+  const [finalTagKey, setFinalTagKey] = useState(tagKey);
+
+  const dialogDescription = addNewLanguage
+    ? tagKey.includes("wheelchair:description")
+      ? t(
+          "Please describe how accessible this place is for wheelchair users. Start by selecting the language for your description.",
+        )
+      : t(
+          "Please describe this place. Start by selecting the language for your description.",
+        )
+    : t("Please edit this description in the same language.");
+
+  const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const descriptionFromServerInSelectedLanguage = useMemo(() => {
+    if (availableLangTags.has(selectedLanguage)) {
+      const newTagKey = `${tagKeyWithoutLangTag}:${selectedLanguage}`;
+      return feature?.properties?.[newTagKey] || "";
+    }
+    return "";
+  }, [
+    selectedLanguage,
+    availableLangTags,
+    feature.properties,
+    tagKeyWithoutLangTag,
+  ]);
+
+  useEffect(() => {
+    setHasDataToSubmit(currentTagValue !== newTagValue);
+  }, [currentTagValue, newTagValue]);
+
+  useEffect(() => {
+    setTextAreaValue(descriptionFromServerInSelectedLanguage);
+    setCurrentTagValue(tagValue);
+    setNewTagValue(tagValue);
+  }, [descriptionFromServerInSelectedLanguage, tagValue]);
+
+  const handleTextAreaChange = (newValue: string) => {
+    setTextAreaValue(newValue);
+    setNewTagValue(newValue);
+    setHasValueChanged(newValue !== tagValue);
+    textAreaRef.current?.focus();
+  };
+
+  useEffect(() => {
+    if (!addNewLanguage || hasValueChanged) {
+      setTimeout(() => {
+        if (textAreaRef.current) {
+          textAreaRef.current.focus();
+        }
+      }, 0);
+    }
+  }, [addNewLanguage, hasValueChanged]);
+
+  const onLanguageChange = React.useCallback(
+    (newPickerValue: string) => {
+      const { normalizedOSMTagKey: baseTag } =
+        normalizeAndExtractLanguageTagsIfPresent(tagKey);
+      const updatedTagName = [baseTag, newPickerValue].join(":");
+
+      if (updatedTagName !== finalTagKey) {
+        setFinalTagKey(updatedTagName);
+      }
+    },
+    [tagKey, finalTagKey],
+  );
+
+  const onSubmit = useSubmit(finalTagKey, newTagValue);
+
+  return (
+    <Dialog.Root open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <Dialog.Content data-testid={`dialog_${tagKey}`}>
+        <Flex direction="column" gap="3">
+          <FeatureNameHeader feature={feature} />
+          <VisuallyHidden asChild>
+            <Dialog.Title>{`Editing ${tagKey}`}</Dialog.Title>
+          </VisuallyHidden>
+
+          <Dialog.Description size="3" mb="4" as="div">
+            <Flex direction="column" gap="3">
+              {dialogDescription}
+              {addNewLanguage && (
+                <Flex gap="2">
+                  <Callout.Root>
+                    <Callout.Icon>
+                      <Info size={18} />
+                    </Callout.Icon>
+                    <Callout.Text as="div">
+                      {t(
+                        "Currently, we support a limited number of languages.",
+                      )}
+                      <br />
+                      {t(
+                        "More will be added soon! If your language is missing, please contact our support team.",
+                      )}
+                    </Callout.Text>
+                  </Callout.Root>
+                </Flex>
+              )}
+            </Flex>
+          </Dialog.Description>
+        </Flex>
+
+        <Flex direction="column" gap="3" style={{ width: "100%" }}>
+          {addNewLanguage && (
+            <Flex align="center" gap="3" style={{ width: "100%" }}>
+              <Text as="label" size="2">
+                {t("Select a language:")}
+              </Text>
+              <Flex style={{ flexGrow: 1 }}>
+                <SearchableSelect
+                  data-testid="searchable-select"
+                  selectPlaceholder={t("Languages")}
+                  items={supportedLanguageTagsOptions}
+                  onSelect={(value) => {
+                    setSelectedLanguage(value);
+                    if (onLanguageChange) {
+                      onLanguageChange(value);
+                      if (!hasValueChanged) {
+                        setHasValueChanged(true);
+                      }
+                    }
+                  }}
+                  ariaLabelForTrigger={t("Select a language")}
+                  ariaLabelForContent={t("List of languages")}
+                />
+              </Flex>
+            </Flex>
+          )}
+
+          <div hidden={addNewLanguage ? !hasValueChanged : false}>
+            <TextArea
+              dir="auto"
+              ref={textAreaRef}
+              aria-label={t("Enter a description here")}
+              defaultValue={addNewLanguage ? undefined : tagValue}
+              value={addNewLanguage ? textAreaValue : undefined}
+              placeholder={t("Enter a description here")}
+              onChange={(evt) => handleTextAreaChange(evt.target.value)}
+              size="2"
+              radius="small"
+              variant="classic"
+            />
+          </div>
+
+          <Dialog.Close>
+            <Flex gap="3" mt="4" justify="end">
+              <SecondaryButton>{t("Cancel")}</SecondaryButton>
+              <PrimaryButton
+                onClick={() => {
+                  if (hasDataToSubmit) {
+                    onSubmit();
+                  }
+                }}
+              >
+                {hasDataToSubmit ? t("Send") : t("Confirm")}
+              </PrimaryButton>
+            </Flex>
+          </Dialog.Close>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+export default DescriptionEditor;

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu.tsx
@@ -1,13 +1,16 @@
 import { DropdownMenu, IconButton } from "@radix-ui/themes";
 import { t } from "@transifex/native";
 import { Pencil } from "lucide-react";
-import React, { useContext, useState } from "react";
-import { AutoEditor } from "~/modules/edit/components/AutoEditor";
-import { FeaturePanelContext } from "../../FeaturePanelContext";
+import React, { useState } from "react";
+import DescriptionEditor from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/DescriptionEditor";
+import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
 
-export function EditDropdownMenu({ tagKey }: { tagKey: string }) {
-  const { features } = useContext(FeaturePanelContext);
-  const feature = features[0].feature?.requestedFeature;
+type Props = {
+  tagKey: string;
+  tagValue: string | undefined;
+  feature: AnyFeature;
+};
+const EditDropdownMenu = ({ tagKey, tagValue, feature }: Props) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [addNewLanguage, setAddNewLanguage] = useState(false);
 
@@ -44,13 +47,17 @@ export function EditDropdownMenu({ tagKey }: { tagKey: string }) {
       </DropdownMenu.Root>
 
       {isDialogOpen && feature && (
-        <AutoEditor
+        <DescriptionEditor
+          isDialogOpen={isDialogOpen}
+          setIsDialogOpen={setIsDialogOpen}
           feature={feature}
           tagKey={tagKey}
+          tagValue={tagValue}
           addNewLanguage={addNewLanguage}
-          onClose={() => setIsDialogOpen(false)}
         />
       )}
     </>
   );
-}
+};
+
+export default EditDropdownMenu;

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagTableRowOrListElement.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagTableRowOrListElement.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "@radix-ui/themes";
 import styled from "styled-components";
 import { EditButton } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditButton";
-import { EditDropdownMenu } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu";
+import EditDropdownMenu from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu";
 import { horizontalKeys } from "~/needs-refactoring/lib/model/osm/tag-config/horizontalKeys";
 import StyledMarkdown from "~/needs-refactoring/components/shared/StyledMarkdown";
 import type { OSMTagProps } from "./OSMTagProps";

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagTableRowOrListElement.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagTableRowOrListElement.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "@radix-ui/themes";
 import styled from "styled-components";
 import { EditButton } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditButton";
-import { EditDropdownMenu } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropDownMenu";
+import { EditDropdownMenu } from "~/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/EditDropdownMenu";
 import { horizontalKeys } from "~/needs-refactoring/lib/model/osm/tag-config/horizontalKeys";
 import StyledMarkdown from "~/needs-refactoring/components/shared/StyledMarkdown";
 import type { OSMTagProps } from "./OSMTagProps";

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/ToiletsWheelchairEditor.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/ToiletsWheelchairEditor.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from "react";
-import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
-import useSubmit from "~/needs-refactoring/components/CombinedFeaturePanel/useSubmit";
 import { Dialog, Flex, IconButton } from "@radix-ui/themes";
 import { t } from "@transifex/native";
-import FeatureNameHeader from "~/needs-refactoring/components/CombinedFeaturePanel/components/FeatureNameHeader";
-import ToiletRadioCards from "~/pages/[placeType]/[id]/_components/ToiletRadioCards";
-import { SecondaryButton } from "~/components/button/SecondaryButton";
-import { PrimaryButton } from "~/components/button/PrimaryButton";
 import { Pencil } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import { PrimaryButton } from "~/components/button/PrimaryButton";
+import { SecondaryButton } from "~/components/button/SecondaryButton";
+import ToiletRadioCards from "~/modules/edit/components/ToiletRadioCards";
+import FeatureNameHeader from "~/needs-refactoring/components/CombinedFeaturePanel/components/FeatureNameHeader";
+import useSubmit from "~/needs-refactoring/components/CombinedFeaturePanel/useSubmit";
+import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
 
 type Props = {
   tagKey: string;

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/ToiletsWheelchairEditor.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/ToiletsWheelchairEditor.tsx
@@ -15,7 +15,7 @@ type Props = {
   feature: AnyFeature;
 };
 
-const ToiletsWheelchairEditorNew = ({ tagKey, tagValue, feature }: Props) => {
+const ToiletsWheelchairEditor = ({ tagKey, tagValue, feature }: Props) => {
   const [editedTagValue, setEditedTagValue] = useState<
     string | number | undefined
   >(tagValue);
@@ -28,11 +28,7 @@ const ToiletsWheelchairEditorNew = ({ tagKey, tagValue, feature }: Props) => {
   return (
     <Dialog.Root>
       <Dialog.Trigger>
-        <IconButton
-          aria-label={t("Edit")}
-          variant="soft"
-          // data-testid={tagKey}
-        >
+        <IconButton aria-label={t("Edit")} variant="soft" data-testid={tagKey}>
           <Pencil size={18} aria-hidden />
         </IconButton>
       </Dialog.Trigger>
@@ -74,4 +70,4 @@ const ToiletsWheelchairEditorNew = ({ tagKey, tagValue, feature }: Props) => {
     </Dialog.Root>
   );
 };
-export default ToiletsWheelchairEditorNew;
+export default ToiletsWheelchairEditor;

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/ToiletsWheelchairEditorNew.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/ToiletsWheelchairEditorNew.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from "react";
+import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
+import useSubmit from "~/needs-refactoring/components/CombinedFeaturePanel/useSubmit";
+import { Dialog, Flex, IconButton } from "@radix-ui/themes";
+import { t } from "@transifex/native";
+import FeatureNameHeader from "~/needs-refactoring/components/CombinedFeaturePanel/components/FeatureNameHeader";
+import ToiletRadioCards from "~/pages/[placeType]/[id]/_components/ToiletRadioCards";
+import { SecondaryButton } from "~/components/button/SecondaryButton";
+import { PrimaryButton } from "~/components/button/PrimaryButton";
+import { Pencil } from "lucide-react";
+
+type Props = {
+  tagKey: string;
+  tagValue: string | undefined;
+  feature: AnyFeature;
+};
+
+const ToiletsWheelchairEditorNew = ({ tagKey, tagValue, feature }: Props) => {
+  const [editedTagValue, setEditedTagValue] = useState<
+    string | number | undefined
+  >(tagValue);
+  const [hasDataToSubmit, setHasDataToSubmit] = useState<boolean>(true);
+  useEffect(() => {
+    setHasDataToSubmit(tagValue !== editedTagValue);
+  }, [tagValue, editedTagValue]);
+  const onSubmit = useSubmit(tagKey, editedTagValue);
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger>
+        <IconButton
+          aria-label={t("Edit")}
+          variant="soft"
+          // data-testid={tagKey}
+        >
+          <Pencil size={18} aria-hidden />
+        </IconButton>
+      </Dialog.Trigger>
+      <Dialog.Content
+        aria-label={t("Toilet Accessibility Editor")}
+        aria-describedby="dialog-description"
+        data-testid="dialog"
+      >
+        <Flex direction="column" gap="4" style={{ padding: "10px" }}>
+          <FeatureNameHeader feature={feature} />
+
+          <Dialog.Description id="dialog-description" size="3" mb="1">
+            {t("Is this toilet wheelchair accessible?")}
+          </Dialog.Description>
+
+          <ToiletRadioCards
+            onSelect={(value) => {
+              setEditedTagValue(value);
+            }}
+            defaultValue={tagValue}
+          />
+
+          <Dialog.Close>
+            <Flex gap="3" mt="4" justify="end">
+              <SecondaryButton>{t("Cancel")}</SecondaryButton>
+              <PrimaryButton
+                onClick={() => {
+                  if (hasDataToSubmit) {
+                    onSubmit();
+                  }
+                }}
+              >
+                {hasDataToSubmit ? t("Send") : t("Confirm")}
+              </PrimaryButton>
+            </Flex>
+          </Dialog.Close>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+export default ToiletsWheelchairEditorNew;

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/WheelchairEditor.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/WheelchairEditor.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from "react";
 import { Dialog, Flex, IconButton } from "@radix-ui/themes";
 import { t } from "@transifex/native";
+import { Pencil } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import { PrimaryButton } from "~/components/button/PrimaryButton";
+import { SecondaryButton } from "~/components/button/SecondaryButton";
+import WheelchairRadioCards from "~/modules/edit/components/WheelchairRadioCards";
 import { StyledReportView } from "~/needs-refactoring/components/CombinedFeaturePanel/ReportView";
 import FeatureNameHeader from "~/needs-refactoring/components/CombinedFeaturePanel/components/FeatureNameHeader";
-import WheelchairRadioCards from "~/pages/[placeType]/[id]/_components/WheelchairRadioCards";
-import { SecondaryButton } from "~/components/button/SecondaryButton";
-import { PrimaryButton } from "~/components/button/PrimaryButton";
-import { Pencil } from "lucide-react";
 import useSubmit from "~/needs-refactoring/components/CombinedFeaturePanel/useSubmit";
 import { useFeatureLabel } from "~/needs-refactoring/components/CombinedFeaturePanel/utils/useFeatureLabel";
 import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/WheelchairEditor.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/WheelchairEditor.tsx
@@ -17,7 +17,7 @@ type Props = {
   feature: AnyFeature;
 };
 
-const WheelchairEditorNew = ({ tagKey, tagValue, feature }: Props) => {
+const WheelchairEditor = ({ tagKey, tagValue, feature }: Props) => {
   const [editedTagValue, setEditedTagValue] = useState<
     string | number | undefined
   >(tagValue);
@@ -35,11 +35,7 @@ const WheelchairEditorNew = ({ tagKey, tagValue, feature }: Props) => {
   return (
     <Dialog.Root>
       <Dialog.Trigger>
-        <IconButton
-          aria-label={t("Edit")}
-          variant="soft"
-          //data-testid={tagKey}
-        >
+        <IconButton aria-label={t("Edit")} variant="soft" data-testid={tagKey}>
           <Pencil size={18} aria-hidden />
         </IconButton>
       </Dialog.Trigger>
@@ -84,4 +80,4 @@ const WheelchairEditorNew = ({ tagKey, tagValue, feature }: Props) => {
     </Dialog.Root>
   );
 };
-export default WheelchairEditorNew;
+export default WheelchairEditor;

--- a/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/WheelchairEditorNew.tsx
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/components/AccessibilitySection/WheelchairEditorNew.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from "react";
+import { Dialog, Flex, IconButton } from "@radix-ui/themes";
+import { t } from "@transifex/native";
+import { StyledReportView } from "~/needs-refactoring/components/CombinedFeaturePanel/ReportView";
+import FeatureNameHeader from "~/needs-refactoring/components/CombinedFeaturePanel/components/FeatureNameHeader";
+import WheelchairRadioCards from "~/pages/[placeType]/[id]/_components/WheelchairRadioCards";
+import { SecondaryButton } from "~/components/button/SecondaryButton";
+import { PrimaryButton } from "~/components/button/PrimaryButton";
+import { Pencil } from "lucide-react";
+import useSubmit from "~/needs-refactoring/components/CombinedFeaturePanel/useSubmit";
+import { useFeatureLabel } from "~/needs-refactoring/components/CombinedFeaturePanel/utils/useFeatureLabel";
+import type { AnyFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
+
+type Props = {
+  tagKey: string;
+  tagValue: string | undefined;
+  feature: AnyFeature;
+};
+
+const WheelchairEditorNew = ({ tagKey, tagValue, feature }: Props) => {
+  const [editedTagValue, setEditedTagValue] = useState<
+    string | number | undefined
+  >(tagValue);
+  const [hasDataToSubmit, setHasDataToSubmit] = useState<boolean>(true);
+  useEffect(() => {
+    setHasDataToSubmit(tagValue !== editedTagValue);
+  }, [tagValue, editedTagValue]);
+
+  const onSubmit = useSubmit(tagKey, editedTagValue);
+
+  const { category } = useFeatureLabel({ feature });
+
+  useEffect(() => {}, [hasDataToSubmit]);
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger>
+        <IconButton
+          aria-label={t("Edit")}
+          variant="soft"
+          //data-testid={tagKey}
+        >
+          <Pencil size={18} aria-hidden />
+        </IconButton>
+      </Dialog.Trigger>
+      <Dialog.Content
+        aria-label={t("Toilet Accessibility Editor")}
+        aria-describedby="dialog-description"
+        data-testid="dialog"
+      >
+        <Flex direction="column" gap="4" style={{ padding: "10px" }}>
+          <StyledReportView className="_view">
+            <FeatureNameHeader feature={feature} />
+
+            <Dialog.Description id="dialog-description" size="3" mb="1">
+              {t("How wheelchair accessible is this place?")}
+            </Dialog.Description>
+
+            <WheelchairRadioCards
+              category={category}
+              onSelect={(value) => {
+                setEditedTagValue(value);
+              }}
+              defaultValue={tagValue}
+            />
+
+            <Dialog.Close>
+              <Flex gap="3" mt="4" justify="end">
+                <SecondaryButton>{t("Cancel")}</SecondaryButton>
+                <PrimaryButton
+                  onClick={() => {
+                    if (hasDataToSubmit) {
+                      onSubmit();
+                    }
+                  }}
+                >
+                  {hasDataToSubmit ? t("Send") : t("Confirm")}
+                </PrimaryButton>
+              </Flex>
+            </Dialog.Close>
+          </StyledReportView>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+export default WheelchairEditorNew;

--- a/src/needs-refactoring/components/CombinedFeaturePanel/useSubmit.ts
+++ b/src/needs-refactoring/components/CombinedFeaturePanel/useSubmit.ts
@@ -1,0 +1,92 @@
+import useUpdateTagValueWithLogInCallback, {
+  type OSMAPIElement,
+} from "~/needs-refactoring/lib/fetchers/osm-api/useUpdateTagValueWithLogIn";
+import { log } from "~/needs-refactoring/lib/util/logger";
+import { updateTagValueNoLogIn } from "~/needs-refactoring/lib/fetchers/updateTagValueNoLogIn";
+import { useSession } from "next-auth/react";
+import { useEnvironment } from "~/hooks/useEnvironment";
+import useOsmApi from "~/hooks/useOsmApi";
+import { isOSMFeature } from "~/needs-refactoring/lib/model/geo/AnyFeature";
+import useSWR from "swr";
+import { fetchFeaturePrefixedId } from "~/needs-refactoring/lib/fetchers/osm-api/fetchFeaturePrefixedId";
+import getOsmParametersFromFeature from "~/needs-refactoring/lib/fetchers/osm-api/getOsmParametersFromFeature";
+import { toast } from "react-toastify";
+import { t } from "@transifex/native";
+import { useContext } from "react";
+import { FeaturePanelContext } from "~/needs-refactoring/components/CombinedFeaturePanel/FeaturePanelContext";
+
+export default function useSubmit(
+  tagKey: string,
+  newTagValue: string | number | undefined,
+) {
+  const { features } = useContext(FeaturePanelContext);
+  const feature = features[0].feature?.requestedFeature;
+
+  const accessToken = useSession().data?.accessToken;
+  const env = useEnvironment();
+  const remoteOSMAPIBaseUrl = env.NEXT_PUBLIC_OSM_API_BASE_URL;
+  if (!remoteOSMAPIBaseUrl) {
+    throw new Error(
+      "Missing OSM API Base URL. Please set the NEXT_PUBLIC_OSM_API_BASE_URL environment variable.",
+    );
+  }
+  const { baseUrl: inhouseOSMAPIBaseURL } = useOsmApi({ cached: false });
+
+  const osmFeature = isOSMFeature(feature) ? feature : undefined;
+  const currentOSMObjectOnServer = useSWR<OSMAPIElement>(
+    osmFeature?._id,
+    fetchFeaturePrefixedId,
+  );
+  const { osmType, osmId } = getOsmParametersFromFeature(osmFeature, tagKey);
+
+  function postSuccessMessage() {
+    toast.success(
+      t("Thank you for contributing. Your edit will be visible soon."),
+    );
+  }
+
+  function postErrorMessage() {
+    toast.error(
+      t("Something went wrong. Please let us know if the error persists."),
+    );
+  }
+
+  const updateTagValueWithLogIn = useUpdateTagValueWithLogInCallback({
+    accessToken,
+    baseUrl: remoteOSMAPIBaseUrl,
+    osmType,
+    osmId,
+    tagName: tagKey,
+    newTagValue,
+    currentOSMObjectOnServer: currentOSMObjectOnServer.data,
+    postSuccessMessage: postSuccessMessage,
+    postErrorMessage: postErrorMessage,
+  });
+
+  const submit = async () => {
+    if (accessToken) {
+      try {
+        await updateTagValueWithLogIn();
+      } catch (error) {
+        log.error(error);
+      }
+      return;
+    }
+
+    try {
+      await updateTagValueNoLogIn({
+        baseUrl: inhouseOSMAPIBaseURL,
+        osmType: osmType,
+        osmId: osmId,
+        tagName: tagKey,
+        newTagValue: newTagValue,
+        postSuccessMessage: postSuccessMessage,
+        postErrorMessage: postErrorMessage,
+      });
+    } catch (error) {
+      log.error(error);
+    }
+  };
+
+  return submit;
+}

--- a/src/needs-refactoring/pages/[placeType]/[id]/report/toilet-accessibility.tsx
+++ b/src/needs-refactoring/pages/[placeType]/[id]/report/toilet-accessibility.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { getLayout } from "~/layouts/DefaultLayout";
+import { ToiletsWheelchairEditorOld } from "~/modules/edit/components/ToiletsWheelchairEditorOld";
 import { FeaturePanelContext } from "~/needs-refactoring/components/CombinedFeaturePanel/FeaturePanelContext";
-import { ToiletsWheelchairEditorOld } from "~/pages/[placeType]/[id]/_components/ToiletsWheelchairEditorOld";
 
 function ToiletAccessibility() {
   const { features } = useContext(FeaturePanelContext);

--- a/src/needs-refactoring/pages/[placeType]/[id]/report/toilet-accessibility.tsx
+++ b/src/needs-refactoring/pages/[placeType]/[id]/report/toilet-accessibility.tsx
@@ -1,14 +1,14 @@
 import React, { useContext } from "react";
 import { getLayout } from "~/layouts/DefaultLayout";
-import { ToiletsWheelchairEditor } from "~/modules/edit/components/ToiletsWheelchairEditor";
 import { FeaturePanelContext } from "~/needs-refactoring/components/CombinedFeaturePanel/FeaturePanelContext";
+import { ToiletsWheelchairEditorOld } from "~/pages/[placeType]/[id]/_components/ToiletsWheelchairEditorOld";
 
 function ToiletAccessibility() {
   const { features } = useContext(FeaturePanelContext);
 
   const feature = features[0];
   return (
-    <ToiletsWheelchairEditor feature={feature} tagKey="toilets:wheelchair" />
+    <ToiletsWheelchairEditorOld feature={feature} tagKey="toilets:wheelchair" />
   );
 }
 

--- a/src/needs-refactoring/pages/[placeType]/[id]/report/wheelchair-accessibility.tsx
+++ b/src/needs-refactoring/pages/[placeType]/[id]/report/wheelchair-accessibility.tsx
@@ -1,13 +1,13 @@
 import React, { useContext } from "react";
 import { getLayout } from "~/layouts/DefaultLayout";
-import { WheelchairEditor } from "~/modules/edit/components/WheelchairEditor";
 import { FeaturePanelContext } from "~/needs-refactoring/components/CombinedFeaturePanel/FeaturePanelContext";
+import { WheelchairEditorOld } from "~/pages/[placeType]/[id]/_components/WheelchairEditorOld";
 
 function WheelchairAccessibility() {
   const { features } = useContext(FeaturePanelContext);
 
   const feature = features[0];
-  return <WheelchairEditor feature={feature} tagKey="wheelchair" />;
+  return <WheelchairEditorOld feature={feature} tagKey="wheelchair" />;
 }
 
 WheelchairAccessibility.getLayout = getLayout;

--- a/src/needs-refactoring/pages/[placeType]/[id]/report/wheelchair-accessibility.tsx
+++ b/src/needs-refactoring/pages/[placeType]/[id]/report/wheelchair-accessibility.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { getLayout } from "~/layouts/DefaultLayout";
+import { WheelchairEditorOld } from "~/modules/edit/components/WheelchairEditorOld";
 import { FeaturePanelContext } from "~/needs-refactoring/components/CombinedFeaturePanel/FeaturePanelContext";
-import { WheelchairEditorOld } from "~/pages/[placeType]/[id]/_components/WheelchairEditorOld";
 
 function WheelchairAccessibility() {
   const { features } = useContext(FeaturePanelContext);


### PR DESCRIPTION
##  🖊️ Description
**💡 What? Why? How?**
I moved all logic from the Auto Editor into a custom hook useSubmit and into the respective editor components to get rid of redundant state and collision with the radix inbuilt keyboard navigation management.

**➕ Additonal comments/questions**

The useSubmit hook and especially the new DescriptionEditor could use some more refactoring but I did not want to go down that lane now. 


[**📎 Related Ticket**](https://app.asana.com/1/1200321573365931/project/1207846019025914/task/1210011562711617?focus=true)


**🔗 PR Dependencies**
I stacked this PR onto the hooks and contexts PR to hopefully ease merging.

https://github.com/sozialhelden/wheelmap-frontend/pull/552

## ⚠️ Creation checklist

**Before creating this merge request, go over the following checklist (click to expand). 
Remove any items that are not applicable.**

<details><summary>💪 I have tested my code</summary>
  
  - [ ] A new E2e playwright test covers this feature / A new test that reproduces the bug passes now.
  - [ ] The feature deployment works.
  - [ ] The automated tests are passing.
  - [x] I have manually tested this feature
    - [ ] on mobile
    - [x] by using keyboard-only navigation
    - [ ] with a screen reader (VoiceOver is fine)
    - [ ] in Chrome
    - [x] in Firefox
    - [ ] in Safari
</details>

<details><summary>🧼 I have cleaned up my code</summary>
  
- [x] I have removed debug logging.
- [x] My code does not generate new warnings.
- [x] The commit messages are precise and make sense (rebase the PR with `--interactive` if applicable, keeping commits in sensible chunks if possible).
</details>

<details><summary>✨ I have created a nice pull request</summary>
  
- [x] It has a clear title.
- [x] It follows the template, has a clear description and testing instructions if needed.
- [x] It references applicable Asana tickets.
- [x] It targets the right branch.
- [x] I removed not applicable sections of the PR template.
- [ ] [optional] I added a GIF of my favorite animal to the PR description to lighten the mood of my colleagues.
</details> 



## 🔍 Reviewing

**When reviewing this merge request, here are some things to keep in mind:**

- [GitLab Code Review Guidelines](https://docs.gitlab.com/ee/development/code_review.html#reviewing-a-merge-request)
- [Conventional Comments](https://conventionalcomments.org/#format)
