### PR TITLE
Improved Darkmode Handling

### DIFF
--- a/src/app/(app)/_components/Logo.tsx
+++ b/src/app/(app)/_components/Logo.tsx
@@ -1,11 +1,14 @@
+"use client";
+
 import { Button } from "@radix-ui/themes";
 import { t } from "@transifex/native";
 import styled from "styled-components";
 import { AppStateAwareLink } from "~/modules/app-state/components/AppStateAwareLink";
+import { useDarkMode } from "~/hooks/useTheme";
 
 import type { WhitelabelBranding } from "~/types/whitelabel";
 
-const StyledButton = styled<{ $beta?: boolean }>(Button)`
+const StyledButton = styled(Button)<{ $beta?: boolean }>`
     position: relative;
     &:before {
         display: ${({ $beta }) => ($beta ? "block" : "none")};
@@ -24,7 +27,7 @@ const StyledButton = styled<{ $beta?: boolean }>(Button)`
         font-size: .7rem;
     }
 `;
-const LogoWide = styled.span`
+const LogoWide = styled.span<{ $darkMode?: boolean }>`
     display: inline-flex;
     align-items: center;
     & > svg {
@@ -34,8 +37,16 @@ const LogoWide = styled.span`
     @media (max-width: 768px) {
         display: none;
     }
+    /* Invert all SVG elements except green ones */
+    ${({ $darkMode }) =>
+      $darkMode &&
+      `
+        & > svg *:not([fill="rgb(73, 185, 68)"]):not([fill="#49b944"]):not([fill="#49B944"]) {
+            filter: invert(1);
+        }
+    `}
 `;
-const LogoSquare = styled.span`
+const LogoSquare = styled.span<{ $darkMode?: boolean }>`
     display: inline-flex;
     align-items: center;
     & > svg {
@@ -45,15 +56,24 @@ const LogoSquare = styled.span`
     @media (min-width: 769px) {
         display: none;
     }
+    ${({ $darkMode }) =>
+      $darkMode &&
+      `
+        & > svg *:not([fill="rgb(73, 185, 68)"]):not([fill="#49b944"]):not([fill="#49B944"]) {
+            filter: invert(1);
+        }
+    `}
 `;
 
 export default function Logo({ branding }: { branding?: WhitelabelBranding }) {
   const beta = true;
+  const darkMode = useDarkMode();
 
   return (
     <StyledButton $beta={beta} variant="ghost" asChild>
       <AppStateAwareLink href="/" aria-label={t("Go to home page")}>
         <LogoWide
+          $darkMode={darkMode}
           // biome-ignore lint/security/noDangerouslySetInnerHtml: SVG code is only set by ourselves.
           dangerouslySetInnerHTML={{
             __html: branding?.vectorLogoSVG?.data ?? "",
@@ -61,6 +81,7 @@ export default function Logo({ branding }: { branding?: WhitelabelBranding }) {
           aria-hidden
         />
         <LogoSquare
+          $darkMode={darkMode}
           // biome-ignore lint/security/noDangerouslySetInnerHtml: SVG code is only set by ourselves.
           dangerouslySetInnerHTML={{
             __html: branding?.vectorIconSVG?.data ?? "",

--- a/src/hooks/osmApiCollections.ts
+++ b/src/hooks/osmApiCollections.ts
@@ -1,0 +1,27 @@
+/**
+ * OSM API collection names. This is in a separate file to avoid circular
+ * dependencies and ensure the array is always available when imported.
+ */
+export const osmApiCollections = [
+  "admin",
+  "amenities",
+  "buildings",
+  "conveying",
+  "elevators",
+  "entrances_or_exits",
+  "master_route_members",
+  "master_routes",
+  "pedestrian_highways",
+  "places",
+  "platforms",
+  "ramps",
+  "route_members",
+  "routes",
+  "stations",
+  "stop_area_members",
+  "stop_areas",
+  "stop_positions",
+  "toilets",
+] as const;
+
+export type OsmApiCollection = (typeof osmApiCollections)[number];

--- a/src/hooks/useOsmApi.ts
+++ b/src/hooks/useOsmApi.ts
@@ -3,33 +3,16 @@ import { useWhitelabel } from "~/hooks/useWhitelabel";
 import { useCategoryFilter } from "~/modules/categories/hooks/useCategoryFilter";
 import { useNeeds } from "~/modules/needs/contexts/NeedsContext";
 import {
-  type NestedRecord,
   flattenToSearchParams,
+  type NestedRecord,
 } from "~/utils/search-params";
+import {
+  type OsmApiCollection,
+  osmApiCollections,
+} from "~/hooks/osmApiCollections"; // Re-export from dedicated file to maintain backward compatibility
 
-export const osmApiCollections = [
-  "admin",
-  "amenities",
-  "buildings",
-  "conveying",
-  "elevators",
-  "entrances_or_exits",
-  "master_route_members",
-  "master_routes",
-  "pedestrian_highways",
-  "places",
-  "platforms",
-  "ramps",
-  "route_members",
-  "routes",
-  "stations",
-  "stop_area_members",
-  "stop_areas",
-  "stop_positions",
-  "toilets",
-] as const;
-
-export type OsmApiCollection = (typeof osmApiCollections)[number];
+// Re-export from dedicated file to maintain backward compatibility
+export { osmApiCollections, type OsmApiCollection };
 
 export type OsmApiProps = {
   tileNumber?: number;

--- a/src/modules/map/sources.ts
+++ b/src/modules/map/sources.ts
@@ -1,5 +1,5 @@
 import type { SourceProps } from "react-map-gl/mapbox-legacy";
-import { osmApiCollections } from "~/hooks/useOsmApi";
+import { osmApiCollections } from "~/hooks/osmApiCollections";
 
 export type ExternalDataSource = {
   /**

--- a/src/needs-refactoring/components/navigation/AddPlaceIconButton.tsx
+++ b/src/needs-refactoring/components/navigation/AddPlaceIconButton.tsx
@@ -1,0 +1,31 @@
+import { IconButton, Theme } from "@radix-ui/themes";
+import { t } from "@transifex/native";
+import { MapPinPlus } from "lucide-react";
+import Link from "next/link";
+import { AppStateAwareLink } from "~/modules/app-state/components/AppStateAwareLink";
+import type { IAutoLinkProps } from "./AppLink";
+
+export default function AddPlaceIconButton({ url, label }: IAutoLinkProps) {
+  if (!url) {
+    return null;
+  }
+
+  const isExternal = url.startsWith("http");
+  const LinkElement = isExternal ? Link : AppStateAwareLink;
+  const ariaLabel = label || t("Add new location");
+
+  return (
+    <Theme radius="small">
+      <IconButton variant="soft" size="3" asChild>
+        <LinkElement
+          href={url}
+          target={isExternal ? "_blank" : undefined}
+          rel={isExternal ? "noreferrer noopener" : undefined}
+          aria-label={ariaLabel}
+        >
+          <MapPinPlus aria-hidden="true" />
+        </LinkElement>
+      </IconButton>
+    </Theme>
+  );
+}

--- a/src/needs-refactoring/components/navigation/AppLink.tsx
+++ b/src/needs-refactoring/components/navigation/AppLink.tsx
@@ -19,6 +19,7 @@ function useAppLinkButtonProps(tags: string[] | undefined): ButtonProps {
     () => ({
       variant: tags?.includes("primary") ? "solid" : "ghost",
       highContrast: !tags?.includes("primary"),
+      size: "3",
     }),
     [tags],
   );

--- a/src/needs-refactoring/components/navigation/AppLink.tsx
+++ b/src/needs-refactoring/components/navigation/AppLink.tsx
@@ -1,6 +1,7 @@
 import type { ButtonProps } from "@radix-ui/themes";
 import { useMemo } from "react";
 import type { useAppLink } from "~/needs-refactoring/lib/useAppLink";
+import AddPlaceIconButton from "./AddPlaceIconButton";
 import ErroneousLink from "./ErroneousLink";
 import ExternalOrInternalLink from "./ExternalOrInternalLink";
 import JoinedEventLink from "./JoinedEventLink";
@@ -41,7 +42,9 @@ export default function AppLink({
   const buttonProps: ButtonProps = useAppLinkButtonProps(tags);
 
   let Element: React.ComponentType<IAutoLinkProps> | null;
-  if (tags?.includes("events")) {
+  if (tags?.includes("primary") && !asMenuItem) {
+    Element = AddPlaceIconButton;
+  } else if (tags?.includes("events")) {
     Element = JoinedEventLink;
   } else if (tags?.includes("session")) {
     Element = SessionElement;

--- a/src/needs-refactoring/components/navigation/DarkModeToggle.tsx
+++ b/src/needs-refactoring/components/navigation/DarkModeToggle.tsx
@@ -1,0 +1,34 @@
+import { IconButton, Theme } from "@radix-ui/themes";
+import { t } from "@transifex/native";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "~/hooks/useTheme";
+
+export default function DarkModeToggle() {
+  const { setTheme, resolvedTheme } = useTheme();
+
+  const isDark = resolvedTheme === "dark";
+
+  const handleClick = () => {
+    setTheme(isDark ? "light" : "dark");
+  };
+
+  const ariaLabel = isDark
+    ? t("Switch to light mode")
+    : t("Switch to dark mode");
+
+  const Icon = isDark ? Sun : Moon;
+
+  return (
+    <Theme radius="small">
+      <IconButton
+        variant="soft"
+        color="gray"
+        size="3"
+        aria-label={ariaLabel}
+        onClick={handleClick}
+      >
+        <Icon aria-hidden="true" />
+      </IconButton>
+    </Theme>
+  );
+}

--- a/src/needs-refactoring/components/navigation/Navigation.tsx
+++ b/src/needs-refactoring/components/navigation/Navigation.tsx
@@ -1,16 +1,15 @@
 import { DropdownMenu, Flex, IconButton, Theme } from "@radix-ui/themes";
 import { supportedLanguageTagsOptions } from "@sozialhelden/core";
 import { t } from "@transifex/native";
-import { CheckIcon, Menu, X } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import styled from "styled-components";
 import { useExpertMode } from "~/hooks/useExpertMode";
-import { useTheme } from "~/hooks/useTheme";
 import { useI18n } from "~/modules/i18n/hooks/useI18n";
 import AppLink from "~/needs-refactoring/components/navigation/AppLink";
 import type { TranslatedAppLink } from "~/needs-refactoring/lib/useAppLink";
 import { useNavigation } from "~/needs-refactoring/lib/useNavigation";
+import DarkModeToggle from "./DarkModeToggle";
 
 function filterExpertModeLinks(
   links: TranslatedAppLink[],
@@ -24,10 +23,6 @@ function filterExpertModeLinks(
   });
 }
 
-const FlexListItem = styled.li`
-    display: flex;
-`;
-
 export default function Navigation() {
   const pathName = usePathname();
   const [isOpen, setIsOpen] = useState(false);
@@ -35,7 +30,7 @@ export default function Navigation() {
 
   useEffect(() => setIsOpen(false), [pathName]);
 
-  const { linksInToolbar, linksInDropdownMenu } = useNavigation();
+  const { primaryLink, linksInDropdownMenu } = useNavigation();
 
   const menuLinkElements = useMemo(
     () =>
@@ -45,18 +40,7 @@ export default function Navigation() {
     [linksInDropdownMenu, isExpertMode],
   );
 
-  const toolbarLinkElements = useMemo(
-    () =>
-      filterExpertModeLinks(linksInToolbar, isExpertMode).map((appLink) => (
-        <FlexListItem key={appLink._id}>
-          <AppLink asMenuItem={false} {...appLink} />
-        </FlexListItem>
-      )),
-    [linksInToolbar, isExpertMode],
-  );
-
   const { languageLabel, setLanguageTag } = useI18n();
-  const { theme, setTheme } = useTheme();
 
   const dropdownMenuButton = menuLinkElements.length > 0 && (
     <Theme radius="small">
@@ -87,30 +71,7 @@ export default function Navigation() {
               </DropdownMenu.SubContent>
             </DropdownMenu.Sub>
           )}
-          <DropdownMenu.Sub>
-            <DropdownMenu.SubTrigger>
-              {t("Choose theme")}
-            </DropdownMenu.SubTrigger>
-            <DropdownMenu.SubContent>
-              <DropdownMenu.Item onClick={() => setTheme("light")} key="light">
-                {t("Light")}
-                {theme === "light" && (
-                  <CheckIcon aria-hidden="true" size={16} />
-                )}
-              </DropdownMenu.Item>
-              <DropdownMenu.Item onClick={() => setTheme("dark")} key="dark">
-                {t("Dark")}
-                {theme === "dark" && <CheckIcon aria-hidden="true" size={16} />}
-              </DropdownMenu.Item>
-              <DropdownMenu.Item onClick={() => setTheme("system")} key="sytem">
-                {t("Auto")}
-                {theme === "system" && (
-                  <CheckIcon aria-hidden="true" size={16} />
-                )}
-              </DropdownMenu.Item>
-            </DropdownMenu.SubContent>
-          </DropdownMenu.Sub>
-          <DropdownMenu.Separator />
+          {isExpertMode && <DropdownMenu.Separator />}
           {menuLinkElements}
         </DropdownMenu.Content>
       </DropdownMenu.Root>
@@ -120,9 +81,8 @@ export default function Navigation() {
   return (
     <Flex gap="4" align="center" asChild>
       <nav aria-label={t("Main")}>
-        <Flex gap="4" align="center" direction={"row"} asChild>
-          <ul>{toolbarLinkElements}</ul>
-        </Flex>
+        {primaryLink && <AppLink asMenuItem={false} {...primaryLink} />}
+        <DarkModeToggle />
         {dropdownMenuButton}
       </nav>
     </Flex>

--- a/src/needs-refactoring/components/navigation/Navigation.tsx
+++ b/src/needs-refactoring/components/navigation/Navigation.tsx
@@ -1,15 +1,21 @@
-import { DropdownMenu, Flex, IconButton, Theme } from "@radix-ui/themes";
+import { DropdownMenu, IconButton, Theme } from "@radix-ui/themes";
 import { supportedLanguageTagsOptions } from "@sozialhelden/core";
 import { t } from "@transifex/native";
-import { Menu, X } from "lucide-react";
+import { Menu, Moon, Plus, Sun, X } from "lucide-react";
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
+import styled from "styled-components";
 import { useExpertMode } from "~/hooks/useExpertMode";
+import { useTheme } from "~/hooks/useTheme";
 import { useI18n } from "~/modules/i18n/hooks/useI18n";
 import AppLink from "~/needs-refactoring/components/navigation/AppLink";
 import type { TranslatedAppLink } from "~/needs-refactoring/lib/useAppLink";
 import { useNavigation } from "~/needs-refactoring/lib/useNavigation";
+import { useWindowSize } from "~/needs-refactoring/lib/util/useViewportSize";
 import DarkModeToggle from "./DarkModeToggle";
+
+const SMALL_VIEWPORT_BREAKPOINT = 1024;
 
 function filterExpertModeLinks(
   links: TranslatedAppLink[],
@@ -23,10 +29,35 @@ function filterExpertModeLinks(
   });
 }
 
+const StyledNav = styled.nav`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-shrink: 0;
+`;
+
+const StyledDropdownMenuContent = styled(DropdownMenu.Content)`
+  --default-font-size: var(--font-size-4);
+  
+  & [data-radix-collection-item] {
+    font-size: var(--font-size-4);
+  }
+`;
+
 export default function Navigation() {
   const pathName = usePathname();
   const [isOpen, setIsOpen] = useState(false);
   const { isExpertMode } = useExpertMode();
+  const { width } = useWindowSize();
+  const isSmallViewport = width < SMALL_VIEWPORT_BREAKPOINT;
+  const { setTheme, resolvedTheme } = useTheme();
+
+  const isDark = resolvedTheme === "dark";
+  const ThemeIcon = isDark ? Sun : Moon;
+
+  const handleThemeToggle = () => {
+    setTheme(isDark ? "light" : "dark");
+  };
 
   useEffect(() => setIsOpen(false), [pathName]);
 
@@ -55,7 +86,30 @@ export default function Navigation() {
             {isOpen ? <X aria-hidden="true" /> : <Menu aria-hidden="true" />}
           </IconButton>
         </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
+        <StyledDropdownMenuContent>
+          {isSmallViewport && primaryLink && (
+            <>
+              <DropdownMenu.Item asChild>
+                <Link href={primaryLink.url || "#"}>
+                  <Plus
+                    size={16}
+                    aria-hidden="true"
+                    style={{ marginRight: 8 }}
+                  />
+                  {primaryLink.label || t("Add new location")}
+                </Link>
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onClick={handleThemeToggle}>
+                <ThemeIcon
+                  size={16}
+                  aria-hidden="true"
+                  style={{ marginRight: 8 }}
+                />
+                {t("Change theme")}
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator />
+            </>
+          )}
           {isExpertMode && (
             <DropdownMenu.Sub>
               <DropdownMenu.SubTrigger>{languageLabel}</DropdownMenu.SubTrigger>
@@ -73,18 +127,22 @@ export default function Navigation() {
           )}
           {isExpertMode && <DropdownMenu.Separator />}
           {menuLinkElements}
-        </DropdownMenu.Content>
+        </StyledDropdownMenuContent>
       </DropdownMenu.Root>
     </Theme>
   );
 
+  // Only show primary link and dark mode toggle outside the menu on large viewports
+  const primaryLinkElement =
+    primaryLink && !isSmallViewport ? (
+      <AppLink asMenuItem={false} {...primaryLink} />
+    ) : null;
+
   return (
-    <Flex gap="4" align="center" asChild>
-      <nav aria-label={t("Main")}>
-        {primaryLink && <AppLink asMenuItem={false} {...primaryLink} />}
-        <DarkModeToggle />
-        {dropdownMenuButton}
-      </nav>
-    </Flex>
+    <StyledNav aria-label={t("Main")}>
+      {primaryLinkElement}
+      {!isSmallViewport && <DarkModeToggle />}
+      {dropdownMenuButton}
+    </StyledNav>
   );
 }

--- a/src/needs-refactoring/components/navigation/Navigation.tsx
+++ b/src/needs-refactoring/components/navigation/Navigation.tsx
@@ -1,7 +1,7 @@
 import { DropdownMenu, IconButton, Theme } from "@radix-ui/themes";
 import { supportedLanguageTagsOptions } from "@sozialhelden/core";
 import { t } from "@transifex/native";
-import { Menu, Moon, Plus, Sun, X } from "lucide-react";
+import { MapPinPlus, Menu, Moon, Sun, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
@@ -15,7 +15,7 @@ import { useNavigation } from "~/needs-refactoring/lib/useNavigation";
 import { useWindowSize } from "~/needs-refactoring/lib/util/useViewportSize";
 import DarkModeToggle from "./DarkModeToggle";
 
-const SMALL_VIEWPORT_BREAKPOINT = 1024;
+const SMALL_VIEWPORT_BREAKPOINT = 480;
 
 function filterExpertModeLinks(
   links: TranslatedAppLink[],
@@ -32,7 +32,7 @@ function filterExpertModeLinks(
 const StyledNav = styled.nav`
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.5rem;
   flex-shrink: 0;
 `;
 
@@ -91,7 +91,7 @@ export default function Navigation() {
             <>
               <DropdownMenu.Item asChild>
                 <Link href={primaryLink.url || "#"}>
-                  <Plus
+                  <MapPinPlus
                     size={16}
                     aria-hidden="true"
                     style={{ marginRight: 8 }}

--- a/src/needs-refactoring/lib/useNavigation.tsx
+++ b/src/needs-refactoring/lib/useNavigation.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useWhitelabel } from "~/hooks/useWhitelabel";
 import { useCurrentMappingEvent } from "~/needs-refactoring/lib/context/useCurrentMappingEvent";
 import { useUniqueSurveyId } from "~/needs-refactoring/lib/context/useUniqueSurveyId";
-import { useWindowSize } from "~/needs-refactoring/lib/util/useViewportSize";
 import { type TranslatedAppLink, useAppLink } from "./useAppLink";
 
 function sortByOrder(a: TranslatedAppLink, b: TranslatedAppLink) {
@@ -10,15 +9,11 @@ function sortByOrder(a: TranslatedAppLink, b: TranslatedAppLink) {
 }
 
 /**
- * @returns An object with two arrays of {@link TranslatedAppLink}: one for the toolbar, one for
- * the menu. The links are sorted by their configured order, and divided depending on importance
- * and current viewport size.
+ * @returns An object with the primary link (add location button) and an array of
+ * {@link TranslatedAppLink} for the dropdown menu. The links are sorted by their configured order.
  */
 
 export function useNavigation() {
-  const windowSize = useWindowSize();
-  const isBigViewport = windowSize.width >= 1024;
-
   const { data: joinedMappingEvent } = useCurrentMappingEvent();
   const app = useWhitelabel();
   const appLinks = app.related?.appLinks;
@@ -29,31 +24,19 @@ export function useNavigation() {
   );
 
   return React.useMemo(() => {
-    // We show some links outside of the menu, and some inside of it.
-    // First, we sort the links into categories:
-    const alwaysVisible = translatedAppLinks.filter(
-      (l) => l.importance === "alwaysVisible",
-    );
-    const advertisedIfPossible = translatedAppLinks.filter(
-      (l) => !l.importance || l.importance === "advertisedIfPossible",
-    );
-    const insignificant = translatedAppLinks.filter(
-      (l) => l.importance === "insignificant",
+    // Primary link (add location button) has the "primary" tag
+    const primaryLink = translatedAppLinks.find((l) =>
+      l.tags?.includes("primary"),
     );
 
-    // Then, we sort the links by their configured order, and return them.
-    const linksInToolbar = [
-      ...(isBigViewport ? advertisedIfPossible : []),
-      ...alwaysVisible,
-    ].sort(sortByOrder);
-    const linksInDropdownMenu = [
-      ...(isBigViewport ? [] : advertisedIfPossible),
-      ...insignificant,
-    ].sort(sortByOrder);
+    // All other links go into the dropdown menu
+    const linksInDropdownMenu = translatedAppLinks
+      .filter((l) => !l.tags?.includes("primary"))
+      .sort(sortByOrder);
 
     return {
-      linksInToolbar,
+      primaryLink,
       linksInDropdownMenu,
     };
-  }, [translatedAppLinks, isBigViewport]);
+  }, [translatedAppLinks]);
 }

--- a/src/needs-refactoring/lib/useNavigation.tsx
+++ b/src/needs-refactoring/lib/useNavigation.tsx
@@ -24,12 +24,10 @@ export function useNavigation() {
   );
 
   return React.useMemo(() => {
-    // Primary link (add location button) has the "primary" tag
     const primaryLink = translatedAppLinks.find((l) =>
       l.tags?.includes("primary"),
     );
 
-    // All other links go into the dropdown menu
     const linksInDropdownMenu = translatedAppLinks
       .filter((l) => !l.tags?.includes("primary"))
       .sort(sortByOrder);

--- a/src/utils/whitelabel.ts
+++ b/src/utils/whitelabel.ts
@@ -11,15 +11,24 @@ export async function getWhitelabelConfig(hostname: string) {
 }
 
 export function sanitizeHostname(hostnameOrIPAddress: string) {
-  return (
-    hostnameOrIPAddress
-      // Allow sharing a deployment with ngrok
-      .replace(/.*\.ngrok(?:-free)\.app$/, "wheelmap.tech")
-      // Allow branch test deployments with a common branding
-      .replace(/.*\.wheelmap\.tech$/, "wheelmap.tech")
+  let hostname = hostnameOrIPAddress
+    // Allow sharing a deployment with ngrok
+    .replace(/.*\.ngrok(?:-free)\.app$/, "wheelmap.tech")
+    // Allow branch test deployments with a common branding
+    .replace(/.*\.wheelmap\.tech$/, "wheelmap.tech");
+
+  // Only replace local/private network IPs in development mode
+  if (process.env.NODE_ENV === "development") {
+    hostname = hostname
       // Use 'localhost' branding for loopback IPs
       .replace(/127\.0\.0\.1/, "localhost")
       .replace(/0\.0\.0\.0/, "localhost")
       .replace(/::1/, "localhost")
-  );
+      // Use 'localhost' branding for private network IPs (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
+      .replace(/^192\.168\.\d{1,3}\.\d{1,3}$/, "localhost")
+      .replace(/^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, "localhost")
+      .replace(/^172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}$/, "localhost");
+  }
+
+  return hostname;
 }


### PR DESCRIPTION
##  🖊️ Description
**💡 What? Why? How?**

**Logo Bug:**
I added a CSS filter in the logo component that inverts the logo colors, exept green. This works for now, but we want to improve this later by deloying a dedicated CMS that will enable everyone to upload assets.

**Navigation Section:**
I moved the links into the hamburger menu and pulled out the darkmode/lightmode toggle. The add new location button stays outside of the menu. On mobile everything is moved inside the hamburger menu and the add link and darkmode toggle are placed at the top of the drop down with a line separating them from the other links.

**Hostname Sanitation:**
In order to be able to test the app on mobile, private network IPs had to be replaced by "localhost" in order for the whitelabel configuration to be retrieved from ac-cloud successfully. Also there was another edge case with circular dependencies which only occured when testing the app on mobile by exposing it in the home network.

**➕ Additonal comments**
I tested this on voice over desktop.

[📎 Related Ticket](https://app.asana.com/1/1200321573365931/project/1208455222043360/task/1210099669460115?focus=true)

## ⚠️ Creation checklist

**Before creating this merge request, go over the following checklist (click to expand). 
Remove any items that are not applicable.**

<details><summary>💪 I have tested my code</summary>
  
  - [ ] A new E2e playwright test covers this feature / A new test that reproduces the bug passes now.
  - [ ] The feature deployment works.
  - [ ] The automated tests are passing.
  - [x] I have manually tested this feature
    - [x] on mobile
    - [x] by using keyboard-only navigation
    - [x] with a screen reader (VoiceOver is fine)
    - [x] in Chrome
    - [x] in Firefox
    - [ ] in Safari
</details>

<details><summary>🧼 I have cleaned up my code</summary>
  
- [x] I have removed dependencies that were just for testing.
- [x] I have removed debug logging.
- [x] My code does not generate new warnings.
- [x] My code does not depend on new vulnerable packages.
- [x] The commit messages are precise and make sense (rebase the PR with `--interactive` if applicable, keeping commits in sensible chunks if possible).
</details>

<details><summary>🔍 I have performed a self-review of my code</summary>
  
- [x] My code is self-documenting or has links to necessary documentation.
- [x] New function and variables names can be understood by new developers with basic project knowledge.
- [x] The feature fits the design.
</details> 

<details><summary>✨ I have created a nice pull request</summary>
  
- [x] It has a clear title.
- [x] It follows the template, has a clear description and testing instructions if needed.
- [x] It references applicable Asana tickets.
- [x] It targets the right branch.
- [x] I removed not applicable sections of the PR template.
- [ ] [optional] I added a GIF of my favorite animal to the PR description to lighten the mood of my colleagues.
</details> 

## 🔍 Reviewing

**When reviewing this merge request, here are some things to keep in mind:**

- [GitLab Code Review Guidelines](https://docs.gitlab.com/ee/development/code_review.html#reviewing-a-merge-request)
- [Conventional Comments](https://conventionalcomments.org/#format)